### PR TITLE
Model and load data packs

### DIFF
--- a/block-data-generated/pom.xml
+++ b/block-data-generated/pom.xml
@@ -31,14 +31,10 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.2</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
-            <version>1.5.2</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -116,19 +112,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.2.0</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <additionalClasspathElements>
-                        <additionalClasspathElement>src/test/java/</additionalClasspathElement>
-                    </additionalClasspathElements>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/data-pack-loader/pom.xml
+++ b/data-pack-loader/pom.xml
@@ -5,37 +5,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>redstone-transformer</artifactId>
         <groupId>net.glowstone</groupId>
+        <artifactId>redstone-transformer</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>block-data-processor</artifactId>
-    <name>Redstone Transformer - Block Data - Processor</name>
-    <url>https://www.glowstone.net</url>
-    <description>Generates Bukkit interface implementations from annotated interfaces and block reports.</description>
+    <artifactId>data-pack-loader</artifactId>
 
     <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>block-data-base</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>block-data-annotations</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.auto.service</groupId>
-            <artifactId>auto-service-annotations</artifactId>
-            <version>1.0-rc6</version>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup</groupId>
-            <artifactId>javapoet</artifactId>
-            <version>1.12.1</version>
-        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -48,6 +25,16 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-runner</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -57,15 +44,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.auto.service</groupId>
-                            <artifactId>auto-service</artifactId>
-                            <version>1.0-rc6</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -77,4 +59,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/DataPackLoader.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/DataPackLoader.java
@@ -1,0 +1,260 @@
+package net.glowstone.datapack.loader;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import net.glowstone.datapack.loader.exception.MalformedDataPackException;
+import net.glowstone.datapack.loader.model.external.Data;
+import net.glowstone.datapack.loader.model.external.DataPack;
+import net.glowstone.datapack.loader.model.external.advancement.Advancement;
+import net.glowstone.datapack.loader.model.external.function.Function;
+import net.glowstone.datapack.loader.model.external.loottable.LootTable;
+import net.glowstone.datapack.loader.model.external.mcmeta.McMeta;
+import net.glowstone.datapack.loader.model.external.predicate.Predicate;
+import net.glowstone.datapack.loader.model.external.recipe.Recipe;
+import net.glowstone.datapack.loader.model.external.structures.Structure;
+import net.glowstone.datapack.loader.model.external.tag.Tag;
+
+public class DataPackLoader {
+    private final ObjectMapper objectMapper;
+
+    public DataPackLoader() {
+        objectMapper = new ObjectMapper()
+            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+            .registerModules(
+                new Jdk8Module()
+            );
+    }
+
+    public Map<String, DataPack> loadPacks(Path dataPacksDirectory) throws IOException {
+        FileSystem fs = dataPacksDirectory.getFileSystem();
+
+        if (!Files.isDirectory(dataPacksDirectory)) {
+            throw new IllegalArgumentException("dataPackDir must be a directory");
+        }
+
+        try {
+            return Files.list(dataPacksDirectory)
+                .map(this::loadDataPackWithName)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+        } catch (UncheckedIOException e) {
+            IOException ioException = e.getCause();
+            e.setStackTrace(
+                Stream.concat(Arrays.stream(ioException.getStackTrace()), Arrays.stream(e.getStackTrace()))
+                    .toArray(StackTraceElement[]::new)
+            );
+            throw e;
+        }
+    }
+
+    private final Optional<Entry<String, DataPack>> loadDataPackWithName(Path dataPackPath) {
+        try {
+            if (Files.isDirectory(dataPackPath)) {
+                String dataPackName = dataPackPath.getFileName().toString();
+                DataPack dataPack = loadDataPackResources(Files.list(dataPackPath).collect(Collectors.toList()));
+                return Optional.of(new SimpleImmutableEntry<>(dataPackName, dataPack));
+            }
+
+            if (dataPackPath.endsWith(".zip")) {
+                String dataPackName = dataPackPath.getFileName().toString();
+                dataPackName = dataPackName.substring(0, dataPackName.length() - 4);
+                FileSystem zipFs = FileSystems.newFileSystem(dataPackPath, getClass().getClassLoader());
+                DataPack dataPack = loadDataPackResources(zipFs.getRootDirectories());
+                return Optional.of(new SimpleImmutableEntry<>(dataPackName, dataPack));
+            }
+
+            return Optional.empty();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private DataPack loadDataPackResources(Iterable<Path> packContents) throws IOException {
+        McMeta mcMeta = null;
+        Map<String, Data> namespacedData = null;
+
+        for (Path rootFilePath : packContents) {
+            switch (rootFilePath.getFileName().toString()) {
+                case "pack.mcmeta":
+                    if (Files.isRegularFile(rootFilePath)) {
+                        mcMeta = objectMapper.readValue(Files.newInputStream(rootFilePath), McMeta.class);
+                    }
+                    break;
+
+                case "data":
+                    if (Files.isDirectory(rootFilePath)) {
+                        namespacedData = Files.list(rootFilePath)
+                            .map(this::loadDataWithName)
+                            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+                    }
+                    break;
+            }
+        }
+
+        if (mcMeta == null) {
+            throw new MalformedDataPackException("Required file 'pack.mcmeta' is missing.");
+        }
+
+        if (namespacedData == null) {
+            throw new MalformedDataPackException("Required directory 'data' is missing.");
+        }
+
+        return new DataPack(mcMeta, namespacedData);
+    }
+
+    private Entry<String, Data> loadDataWithName(Path namespacePath) {
+        try {
+            String namespaceName = namespacePath.getFileName().toString();
+            Data data = new Data(
+                loadAdvancements(namespacePath),
+                loadFunctions(namespacePath),
+                loadLootTables(namespacePath),
+                loadPredicates(namespacePath),
+                loadRecipes(namespacePath),
+                loadStructures(namespacePath),
+                loadTags(namespacePath, "blocks"),
+                loadTags(namespacePath, "entity_types"),
+                loadTags(namespacePath, "fluids"),
+                loadTags(namespacePath, "functions"),
+                loadTags(namespacePath, "items")
+            );
+
+            return new SimpleImmutableEntry<>(namespaceName, data);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Map<String, Advancement> loadAdvancements(Path namespacePath) throws IOException {
+        Map<String, Advancement> advancements = new HashMap<>();
+
+        Path advancementsPath = namespacePath.resolve("advancements");
+        for (Entry<String, Path> resource : iterateResourceFiles(advancementsPath, ".json")) {
+            try {
+                advancements.put(resource.getKey(), objectMapper.readValue(Files.newInputStream(resource.getValue()), Advancement.class));
+            } catch (IOException e) {
+                throw new IOException("Could not parse " + resource.getValue(), e);
+            }
+        }
+
+        return advancements;
+    }
+
+    private Map<String, Function> loadFunctions(Path namespacePath) throws IOException {
+        Map<String, Function> functions = new HashMap<>();
+
+        Path functionsPath = namespacePath.resolve("functions");
+        for (Entry<String, Path> resource : iterateResourceFiles(functionsPath, ".mcfunction")) {
+            List<String> commands = Files.readAllLines(resource.getValue())
+                .stream()
+                .map(String::trim)
+                .filter((s) -> !s.startsWith("#"))
+                .collect(Collectors.toList());
+            functions.put(resource.getKey(), new Function(commands));
+        }
+
+        return functions;
+    }
+
+    private Map<String, LootTable> loadLootTables(Path namespacePath) throws IOException {
+        Map<String, LootTable> lootTables = new HashMap<>();
+
+        Path lootTablePath = namespacePath.resolve("loot_tables");
+        for (Entry<String, Path> resource : iterateResourceFiles(lootTablePath, ".json")) {
+            try {
+                lootTables.put(resource.getKey(), objectMapper.readValue(Files.newInputStream(resource.getValue()), LootTable.class));
+            } catch (IOException e) {
+                throw new IOException("Could not parse " + resource.getValue(), e);
+            }
+        }
+
+        return lootTables;
+    }
+
+    private Map<String, Predicate> loadPredicates(Path namespacePath) throws IOException {
+        Map<String, Predicate> predicates = new HashMap<>();
+
+        Path predicatesPath = namespacePath.resolve("predicates");
+        for (Entry<String, Path> resource : iterateResourceFiles(predicatesPath, ".json")) {
+            predicates.put(resource.getKey(), objectMapper.readValue(Files.newInputStream(resource.getValue()), Predicate.class));
+        }
+
+        return predicates;
+    }
+
+    private Map<String, Recipe> loadRecipes(Path namespacePath) throws IOException {
+        Map<String, Recipe> recipes = new HashMap<>();
+
+        Path recipesPath = namespacePath.resolve("recipes");
+        for (Entry<String, Path> resource : iterateResourceFiles(recipesPath, ".json")) {
+            recipes.put(resource.getKey(), objectMapper.readValue(Files.newInputStream(resource.getValue()), Recipe.class));
+        }
+
+        return recipes;
+    }
+
+    private Map<String, Structure> loadStructures(Path namespacePath) throws IOException {
+        Map<String, Structure> structures = new HashMap<>();
+
+        Path functionsPath = namespacePath.resolve("structure");
+        for (Entry<String, Path> resource : iterateResourceFiles(functionsPath, ".nbt")) {
+            String nbt = String.join("\n", Files.readAllLines(resource.getValue()));
+            structures.put(resource.getKey(), new Structure(nbt));
+        }
+
+        return structures;
+    }
+
+    private Map<String, Tag> loadTags(Path namespacePath, String tagGroup) throws IOException {
+        Map<String, Tag> tags = new HashMap<>();
+
+        Path tagGroupPath = namespacePath.resolve("tags").resolve(tagGroup);
+        for (Entry<String, Path> resource : iterateResourceFiles(tagGroupPath, ".json")) {
+            tags.put(resource.getKey(), objectMapper.readValue(Files.newInputStream(resource.getValue()), Tag.class));
+        }
+
+        return tags;
+    }
+
+    private Iterable<Entry<String, Path>> iterateResourceFiles(Path parentDir, String extension) {
+        if (Files.isDirectory(parentDir)) {
+            return () -> {
+                try {
+                    Stream<Entry<String, Path>> filePathStream = Files.walk(parentDir)
+                        .filter((filePath) -> Files.isRegularFile(filePath) && filePath.toString().endsWith(extension))
+                        .map((filePath) -> {
+                            String resourceName = StreamSupport.stream(parentDir.relativize(filePath).spliterator(), false)
+                                .map(Object::toString)
+                                .collect(Collectors.joining("/"));
+                            resourceName = resourceName.substring(0, resourceName.length() - extension.length());
+                            return new SimpleImmutableEntry<>(resourceName, filePath);
+                        });
+                    return filePathStream.iterator();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            };
+        }
+        return Collections.emptyList();
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/exception/MalformedDataPackException.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/exception/MalformedDataPackException.java
@@ -1,0 +1,7 @@
+package net.glowstone.datapack.loader.exception;
+
+public class MalformedDataPackException extends RuntimeException {
+    public MalformedDataPackException(String message) {
+        super(message);
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/jackson/JsonNodeHandling.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/jackson/JsonNodeHandling.java
@@ -1,0 +1,94 @@
+package net.glowstone.datapack.loader.jackson;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.math.DoubleMath;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+
+public class JsonNodeHandling {
+    public static Optional<String> valueAsString(JsonNode rootNode, String propName) throws JsonMappingException {
+        if (!rootNode.has(propName)) {
+            return Optional.empty();
+        }
+        JsonNode valueNode = rootNode.get(propName);
+        if (!valueNode.isTextual()) {
+            throw new JsonMappingException(null, "Cannot deserialize string prop " + propName);
+        }
+        return Optional.of(valueNode.textValue());
+    }
+
+    public static Optional<Boolean> valueAsBoolean(JsonNode rootNode, String propName) throws JsonMappingException {
+        if (!rootNode.has(propName)) {
+            return Optional.empty();
+        }
+        JsonNode valueNode = rootNode.get(propName);
+        if (!valueNode.isBoolean()) {
+            throw new JsonMappingException(null, "Cannot deserialize boolean prop " + propName);
+        }
+        return Optional.of(valueNode.booleanValue());
+    }
+
+    public static OptionalInt valueAsInt(JsonNode rootNode, String propName) throws JsonMappingException {
+        if (!rootNode.has(propName)) {
+            return OptionalInt.empty();
+        }
+        JsonNode valueNode = rootNode.get(propName);
+        if (valueNode.isInt()) {
+            return OptionalInt.of(valueNode.intValue());
+        } else if (valueNode.isDouble()) {
+            double value = valueNode.asDouble();
+            if (DoubleMath.isMathematicalInteger(value)) {
+                return OptionalInt.of((int)value);
+            }
+        }
+        throw new JsonMappingException(null, "Cannot deserialize int prop " + propName);
+
+    }
+
+    public static OptionalDouble valueAsDouble(JsonNode rootNode, String propName) throws JsonMappingException {
+        if (!rootNode.has(propName)) {
+            return OptionalDouble.empty();
+        }
+        JsonNode valueNode = rootNode.get(propName);
+        if (!valueNode.isDouble()) {
+            throw new JsonMappingException(null, "Cannot deserialize double prop " + propName);
+        }
+        return OptionalDouble.of(valueNode.doubleValue());
+    }
+
+    public static <T> Optional<T> valueAsObject(JsonNode rootNode, String propName, JsonNodeMapper<T> delegate) throws JsonMappingException {
+        if (!rootNode.has(propName)) {
+            return Optional.empty();
+        }
+        JsonNode valueNode = rootNode.get(propName);
+        if (!valueNode.isObject()) {
+            throw new JsonMappingException(null, "Cannot deserialize array prop " + propName);
+        }
+        return Optional.of(delegate.apply(valueNode));
+    }
+
+    public static <T> Optional<List<T>> valueAsList(JsonNode rootNode, String propName, JsonNodeMapper<T> delegate) throws JsonMappingException {
+        if (!rootNode.has(propName)) {
+            return Optional.empty();
+        }
+        JsonNode valueNode = rootNode.get(propName);
+        if (!valueNode.isArray()) {
+            throw new JsonMappingException(null, "Cannot deserialize array prop " + propName);
+        }
+        List<T> rawJsonTexts = new ArrayList<>(valueNode.size());
+        for (int i = 0; i < valueNode.size(); i++) {
+            rawJsonTexts.add(delegate.apply(valueNode.get(i)));
+        }
+        return Optional.of(rawJsonTexts);
+    }
+
+    @FunctionalInterface
+    public interface JsonNodeMapper<T> {
+        T apply(JsonNode rootNode) throws JsonMappingException;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/Data.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/Data.java
@@ -1,0 +1,93 @@
+package net.glowstone.datapack.loader.model.external;
+
+import java.util.Map;
+import net.glowstone.datapack.loader.model.external.advancement.Advancement;
+import net.glowstone.datapack.loader.model.external.function.Function;
+import net.glowstone.datapack.loader.model.external.loottable.LootTable;
+import net.glowstone.datapack.loader.model.external.predicate.Predicate;
+import net.glowstone.datapack.loader.model.external.recipe.Recipe;
+import net.glowstone.datapack.loader.model.external.structures.Structure;
+import net.glowstone.datapack.loader.model.external.tag.Tag;
+
+public class Data {
+    private final Map<String, Advancement> advancements;
+    private final Map<String, Function> functions;
+    private final Map<String, LootTable> lootTables;
+    private final Map<String, Predicate> predicates;
+    private final Map<String, Recipe> recipes;
+    private final Map<String, Structure> structures;
+    private final Map<String, Tag> blockTags;
+    private final Map<String, Tag> itemTags;
+    private final Map<String, Tag> entityTypeTags;
+    private final Map<String, Tag> fluidTags;
+    private final Map<String, Tag> functionTags;
+
+    public Data(
+        Map<String, Advancement> advancements,
+        Map<String, Function> functions,
+        Map<String, LootTable> lootTables,
+        Map<String, Predicate> predicates,
+        Map<String, Recipe> recipes,
+        Map<String, Structure> structures,
+        Map<String, Tag> blockTags,
+        Map<String, Tag> itemTags,
+        Map<String, Tag> entityTypeTags,
+        Map<String, Tag> fluidTags,
+        Map<String, Tag> functionTags) {
+        this.advancements = advancements;
+        this.functions = functions;
+        this.lootTables = lootTables;
+        this.predicates = predicates;
+        this.recipes = recipes;
+        this.structures = structures;
+        this.blockTags = blockTags;
+        this.itemTags = itemTags;
+        this.entityTypeTags = entityTypeTags;
+        this.fluidTags = fluidTags;
+        this.functionTags = functionTags;
+    }
+
+    public Map<String, Advancement> getAdvancements() {
+        return advancements;
+    }
+
+    public Map<String, Function> getFunctions() {
+        return functions;
+    }
+
+    public Map<String, LootTable> getLootTables() {
+        return lootTables;
+    }
+
+    public Map<String, Predicate> getPredicates() {
+        return predicates;
+    }
+
+    public Map<String, Recipe> getRecipes() {
+        return recipes;
+    }
+
+    public Map<String, Structure> getStructures() {
+        return structures;
+    }
+
+    public Map<String, Tag> getBlockTags() {
+        return blockTags;
+    }
+
+    public Map<String, Tag> getItemTags() {
+        return itemTags;
+    }
+
+    public Map<String, Tag> getEntityTypeTags() {
+        return entityTypeTags;
+    }
+
+    public Map<String, Tag> getFluidTags() {
+        return fluidTags;
+    }
+
+    public Map<String, Tag> getFunctionTags() {
+        return functionTags;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/DataPack.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/DataPack.java
@@ -1,0 +1,22 @@
+package net.glowstone.datapack.loader.model.external;
+
+import java.util.Map;
+import net.glowstone.datapack.loader.model.external.mcmeta.McMeta;
+
+public class DataPack {
+    private final McMeta mcMeta;
+    private final Map<String, Data> namespacedData;
+
+    public DataPack(McMeta mcMeta, Map<String, Data> namespacedData) {
+        this.mcMeta = mcMeta;
+        this.namespacedData = namespacedData;
+    }
+
+    public McMeta getMcMeta() {
+        return mcMeta;
+    }
+
+    public Map<String, Data> getNamespacedData() {
+        return namespacedData;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/Advancement.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/Advancement.java
@@ -1,0 +1,49 @@
+package net.glowstone.datapack.loader.model.external.advancement;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+public class Advancement {
+    private final Display display;
+    private final String parent;
+    private final Map<String, Criteria> criteria;
+    private final List<List<String>> requirements;
+    private final Rewards rewards;
+
+    @JsonCreator
+    public Advancement(
+        @JsonProperty("display") Display display,
+        @JsonProperty("parent") String parent,
+        @JsonProperty("criteria") Map<String, Criteria> criteria,
+        @JsonProperty("requirements") List<List<String>> requirements,
+        @JsonProperty("rewards") Rewards rewards) {
+        this.display = display;
+        this.parent = parent;
+        this.criteria = criteria;
+        this.requirements = requirements;
+        this.rewards = rewards;
+    }
+
+    public Display getDisplay() {
+        return display;
+    }
+
+    public String getParent() {
+        return parent;
+    }
+
+    public Map<String, Criteria> getCriteria() {
+        return criteria;
+    }
+
+    public List<List<String>> getRequirements() {
+        return requirements;
+    }
+
+    public Rewards getRewards() {
+        return rewards;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/Criteria.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/Criteria.java
@@ -1,0 +1,252 @@
+package net.glowstone.datapack.loader.model.external.advancement;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import net.glowstone.datapack.loader.model.external.advancement.condition.BeeNestDestroyedConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.BredAnimalsConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.BrewedPotionConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.ChangedDimensionConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.ChanneledLightningConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.Conditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.ConstructBeaconConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.ConsumeItemConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.CuredZombieVillagerConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.EffectsChangedConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.EnchantedItemConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.EnterBlockConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.EntityHurtPlayerConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.EntityKilledPlayerConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.FilledBucketConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.FishingRodHookedConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.HeroOfTheVillageConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.ImpossibleConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.InventoryChangedConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.ItemDurabilityChangedConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.KilledByCrossbowConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.LevitationConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.LocationConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.NetherTravelConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.PlacedBlockConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.PlayerHurtEntityConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.PlayerKilledEntityConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.RecipeUnlockedConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.SafelyHarvestHoneyConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.ShotCrossbowConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.SleptInBedConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.SlideDownBlockConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.SummonedEntityConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.TameAnimalConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.TickConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.UsedEnderEyeConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.UsedTotemConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.VillagerTradeConditions;
+import net.glowstone.datapack.loader.model.external.advancement.condition.VoluntaryExileConditions;
+
+import java.io.IOException;
+
+@JsonDeserialize(using = Criteria.CriteriaDeserializer.class)
+public class Criteria {
+    public static class CriteriaDeserializer extends StdDeserializer<Criteria> {
+        public CriteriaDeserializer() {
+            super(Criteria.class);
+        }
+
+        @Override
+        public Criteria deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            ObjectCodec codec = p.getCodec();
+
+            if (p.getCurrentToken() == JsonToken.START_OBJECT) {
+                JsonNode rootNode = p.readValueAsTree();
+                JsonNode typeNode = rootNode.get("trigger");
+                JsonNode conditionsNode = rootNode.get("conditions");
+
+                if (conditionsNode == null) {
+                    conditionsNode = (JsonNode) codec.createObjectNode();
+                }
+
+                if (typeNode != null && typeNode.isTextual() && conditionsNode.isObject()) {
+                    Conditions conditions = null;
+                    switch (typeNode.asText()) {
+                        case BeeNestDestroyedConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, BeeNestDestroyedConditions.class);
+                            break;
+
+                        case BredAnimalsConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, BredAnimalsConditions.class);
+                            break;
+
+                        case BrewedPotionConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, BrewedPotionConditions.class);
+                            break;
+
+                        case ChangedDimensionConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, ChangedDimensionConditions.class);
+                            break;
+
+                        case ChanneledLightningConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, ChanneledLightningConditions.class);
+                            break;
+
+                        case ConstructBeaconConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, ConstructBeaconConditions.class);
+                            break;
+
+                        case ConsumeItemConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, ConsumeItemConditions.class);
+                            break;
+
+                        case CuredZombieVillagerConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, CuredZombieVillagerConditions.class);
+                            break;
+
+                        case EffectsChangedConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, EffectsChangedConditions.class);
+                            break;
+
+                        case EnchantedItemConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, EnchantedItemConditions.class);
+                            break;
+
+                        case EnterBlockConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, EnterBlockConditions.class);
+                            break;
+
+                        case EntityHurtPlayerConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, EntityHurtPlayerConditions.class);
+                            break;
+
+                        case EntityKilledPlayerConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, EntityKilledPlayerConditions.class);
+                            break;
+
+                        case FilledBucketConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, FilledBucketConditions.class);
+                            break;
+
+                        case FishingRodHookedConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, FishingRodHookedConditions.class);
+                            break;
+
+                        case HeroOfTheVillageConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, HeroOfTheVillageConditions.class);
+                            break;
+
+                        case ImpossibleConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, ImpossibleConditions.class);
+                            break;
+
+                        case InventoryChangedConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, InventoryChangedConditions.class);
+                            break;
+
+                        case ItemDurabilityChangedConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, ItemDurabilityChangedConditions.class);
+                            break;
+
+                        case KilledByCrossbowConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, KilledByCrossbowConditions.class);
+                            break;
+
+                        case LevitationConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, LevitationConditions.class);
+                            break;
+
+                        case LocationConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, LocationConditions.class);
+                            break;
+
+                        case NetherTravelConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, NetherTravelConditions.class);
+                            break;
+
+                        case PlacedBlockConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, PlacedBlockConditions.class);
+                            break;
+
+                        case PlayerHurtEntityConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, PlayerHurtEntityConditions.class);
+                            break;
+
+                        case PlayerKilledEntityConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, PlayerKilledEntityConditions.class);
+                            break;
+
+                        case RecipeUnlockedConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, RecipeUnlockedConditions.class);
+                            break;
+
+                        case SafelyHarvestHoneyConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, SafelyHarvestHoneyConditions.class);
+                            break;
+
+                        case ShotCrossbowConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, ShotCrossbowConditions.class);
+                            break;
+
+                        case SleptInBedConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, SleptInBedConditions.class);
+                            break;
+
+                        case SlideDownBlockConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, SlideDownBlockConditions.class);
+                            break;
+
+                        case SummonedEntityConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, SummonedEntityConditions.class);
+                            break;
+
+                        case TameAnimalConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, TameAnimalConditions.class);
+                            break;
+
+                        case TickConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, TickConditions.class);
+                            break;
+
+                        case UsedEnderEyeConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, UsedEnderEyeConditions.class);
+                            break;
+
+                        case UsedTotemConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, UsedTotemConditions.class);
+                            break;
+
+                        case VillagerTradeConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, VillagerTradeConditions.class);
+                            break;
+
+                        case VoluntaryExileConditions.TYPE_ID:
+                            conditions = codec.treeToValue(conditionsNode, VoluntaryExileConditions.class);
+                            break;
+                    }
+                    if (conditions != null) {
+                        return new Criteria(conditions);
+                    }
+                }
+            }
+
+            throw new JsonMappingException(p, "Could not create Criteria");
+        }
+    }
+
+    private final Conditions conditions;
+
+    public Criteria(Conditions conditions) {
+        this.conditions = conditions;
+    }
+
+    public Conditions getConditions() {
+        return conditions;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/Display.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/Display.java
@@ -1,0 +1,68 @@
+package net.glowstone.datapack.loader.model.external.advancement;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.text.RawJsonText;
+
+public class Display {
+    private final Icon icon;
+    private final RawJsonText title;
+    private final String frame;
+    private final String background;
+    private final RawJsonText description;
+    private final boolean showToast;
+    private final boolean announceToChat;
+    private final boolean hidden;
+
+    @JsonCreator
+    public Display(
+        @JsonProperty("icon") Icon icon,
+        @JsonProperty("title") RawJsonText title,
+        @JsonProperty("frame") String frame,
+        @JsonProperty("background") String background,
+        @JsonProperty("description") RawJsonText description,
+        @JsonProperty("show_toast") boolean showToast,
+        @JsonProperty("announce_to_chat") boolean announceToChat,
+        @JsonProperty("hidden") boolean hidden) {
+        this.icon = icon;
+        this.title = title;
+        this.frame = frame;
+        this.background = background;
+        this.description = description;
+        this.showToast = showToast;
+        this.announceToChat = announceToChat;
+        this.hidden = hidden;
+    }
+
+    public Icon getIcon() {
+        return icon;
+    }
+
+    public RawJsonText getTitle() {
+        return title;
+    }
+
+    public String getFrame() {
+        return frame;
+    }
+
+    public String getBackground() {
+        return background;
+    }
+
+    public RawJsonText getDescription() {
+        return description;
+    }
+
+    public boolean getShowToast() {
+        return showToast;
+    }
+
+    public boolean getAnnounceToChat() {
+        return announceToChat;
+    }
+
+    public boolean getHidden() {
+        return hidden;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/Icon.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/Icon.java
@@ -1,0 +1,25 @@
+package net.glowstone.datapack.loader.model.external.advancement;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Icon {
+    private final String item;
+    private final String nbt;
+
+    @JsonCreator
+    public Icon(
+        @JsonProperty("item") String item,
+        @JsonProperty("nbt") String nbt) {
+        this.item = item;
+        this.nbt = nbt;
+    }
+
+    public String getItem() {
+        return item;
+    }
+
+    public String getNbt() {
+        return nbt;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/Rewards.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/Rewards.java
@@ -1,0 +1,43 @@
+package net.glowstone.datapack.loader.model.external.advancement;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class Rewards {
+    private final Optional<List<String>> recipes;
+    private final Optional<List<String>> loot;
+    private final OptionalInt experience;
+    private final Optional<String> function;
+
+    @JsonCreator
+    public Rewards(
+        @JsonProperty("recipes") Optional<List<String>> recipes,
+        @JsonProperty("loot") Optional<List<String>> loot,
+        @JsonProperty("experience") OptionalInt experience,
+        @JsonProperty("function") Optional<String> function) {
+        this.recipes = recipes;
+        this.loot = loot;
+        this.experience = experience;
+        this.function = function;
+    }
+
+    public Optional<List<String>> getRecipes() {
+        return recipes;
+    }
+
+    public Optional<List<String>> getLoot() {
+        return loot;
+    }
+
+    public OptionalInt getExperience() {
+        return experience;
+    }
+
+    public Optional<String> getFunction() {
+        return function;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/BeeNestDestroyedConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/BeeNestDestroyedConditions.java
@@ -1,0 +1,38 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Item;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class BeeNestDestroyedConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:bee_nest_destroyed";
+
+    private final Optional<String> block;
+    private final Optional<Item> item;
+    private final OptionalInt numBeesInside;
+
+    @JsonCreator
+    public BeeNestDestroyedConditions(
+        @JsonProperty("block") Optional<String> block,
+        @JsonProperty("item") Optional<Item> item,
+        @JsonProperty("num_bees_inside") OptionalInt numBeesInside) {
+        this.block = block;
+        this.item = item;
+        this.numBeesInside = numBeesInside;
+    }
+
+    public Optional<String> getBlock() {
+        return block;
+    }
+
+    public Optional<Item> getItem() {
+        return item;
+    }
+
+    public OptionalInt getNumBeesInside() {
+        return numBeesInside;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/BredAnimalsConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/BredAnimalsConditions.java
@@ -1,0 +1,37 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+
+import java.util.Optional;
+
+public class BredAnimalsConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:bred_animals";
+
+    private final Optional<Entity> child;
+    private final Optional<Entity> parent;
+    private final Optional<Entity> partner;
+
+    @JsonCreator
+    public BredAnimalsConditions(
+        @JsonProperty("child") Optional<Entity> child,
+        @JsonProperty("parent") Optional<Entity> parent,
+        @JsonProperty("partner") Optional<Entity> partner) {
+        this.child = child;
+        this.parent = parent;
+        this.partner = partner;
+    }
+
+    public Optional<Entity> getChild() {
+        return child;
+    }
+
+    public Optional<Entity> getParent() {
+        return parent;
+    }
+
+    public Optional<Entity> getPartner() {
+        return partner;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/BrewedPotionConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/BrewedPotionConditions.java
@@ -1,0 +1,22 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class BrewedPotionConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:brewed_potion";
+
+    private final Optional<String> potion;
+
+    @JsonCreator
+    public BrewedPotionConditions(
+        @JsonProperty("potion") Optional<String> potion) {
+        this.potion = potion;
+    }
+
+    public Optional<String> getPotion() {
+        return potion;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ChangedDimensionConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ChangedDimensionConditions.java
@@ -1,0 +1,29 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class ChangedDimensionConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:changed_dimension";
+
+    private final Optional<String> from;
+    private final Optional<String> to;
+
+    @JsonCreator
+    public ChangedDimensionConditions(
+        @JsonProperty("from") Optional<String> from,
+        @JsonProperty("to") Optional<String> to) {
+        this.from = from;
+        this.to = to;
+    }
+
+    public Optional<String> getFrom() {
+        return from;
+    }
+
+    public Optional<String> getTo() {
+        return to;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ChanneledLightningConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ChanneledLightningConditions.java
@@ -1,0 +1,24 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+
+import java.util.List;
+import java.util.Optional;
+
+public class ChanneledLightningConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:channeled_lightning";
+
+    private final Optional<List<Entity>> victims;
+
+    @JsonCreator
+    public ChanneledLightningConditions(
+        @JsonProperty("victims") Optional<List<Entity>> victims) {
+        this.victims = victims;
+    }
+
+    public Optional<List<Entity>> getVictims() {
+        return victims;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/Conditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/Conditions.java
@@ -1,0 +1,4 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+public interface Conditions {
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ConstructBeaconConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ConstructBeaconConditions.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+
+import java.util.Optional;
+
+public class ConstructBeaconConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:construct_beacon";
+
+    private final Optional<RangedInt> level;
+
+    @JsonCreator
+    public ConstructBeaconConditions(
+        @JsonProperty("level") Optional<RangedInt> level) {
+        this.level = level;
+    }
+
+    public Optional<RangedInt> getLevel() {
+        return level;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ConsumeItemConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ConsumeItemConditions.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Item;
+
+import java.util.Optional;
+
+public class ConsumeItemConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:consume_item";
+    
+    private final Optional<Item> item;
+
+    @JsonCreator
+    public ConsumeItemConditions(
+        @JsonProperty("item") Optional<Item> item) {
+        this.item = item;
+    }
+
+    public Optional<Item> getItem() {
+        return item;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/CuredZombieVillagerConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/CuredZombieVillagerConditions.java
@@ -1,0 +1,30 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+
+import java.util.Optional;
+
+public class CuredZombieVillagerConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:cured_zombie_villager";
+
+    private final Optional<Entity> villager;
+    private final Optional<Entity> zombie;
+
+    @JsonCreator
+    public CuredZombieVillagerConditions(
+        @JsonProperty("villager") Optional<Entity> villager,
+        @JsonProperty("zombie") Optional<Entity> zombie) {
+        this.villager = villager;
+        this.zombie = zombie;
+    }
+
+    public Optional<Entity> getVillager() {
+        return villager;
+    }
+
+    public Optional<Entity> getZombie() {
+        return zombie;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/EffectsChangedConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/EffectsChangedConditions.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Effect;
+
+import java.util.Map;
+
+public class EffectsChangedConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:effects_changed";
+
+    private final Map<String, Effect> effects;
+
+    @JsonCreator
+    public EffectsChangedConditions(
+        @JsonProperty("effects") Map<String, Effect> effects) {
+        this.effects = effects;
+    }
+
+    public Map<String, Effect> getEffects() {
+        return effects;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/EnchantedItemConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/EnchantedItemConditions.java
@@ -1,0 +1,31 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Item;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+
+import java.util.Optional;
+
+public class EnchantedItemConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:enchanted_item";
+
+    private final Optional<Item> item;
+    private final Optional<RangedInt> levels;
+
+    @JsonCreator
+    public EnchantedItemConditions(
+        @JsonProperty("item") Optional<Item> item,
+        @JsonProperty("levels") Optional<RangedInt> levels) {
+        this.item = item;
+        this.levels = levels;
+    }
+
+    public Optional<Item> getItem() {
+        return item;
+    }
+
+    public Optional<RangedInt> getLevels() {
+        return levels;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/EnterBlockConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/EnterBlockConditions.java
@@ -1,0 +1,30 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class EnterBlockConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:enter_block";
+
+    private final Optional<String> block;
+    private final Optional<Map<String, String>> state;
+
+    @JsonCreator
+    public EnterBlockConditions(
+        @JsonProperty("block") Optional<String> block,
+        @JsonProperty("state") Optional<Map<String, String>> state) {
+        this.block = block;
+        this.state = state;
+    }
+
+    public Optional<String> getBlock() {
+        return block;
+    }
+
+    public Optional<Map<String, String>> getState() {
+        return state;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/EntityHurtPlayerConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/EntityHurtPlayerConditions.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Damage;
+
+import java.util.Optional;
+
+public class EntityHurtPlayerConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:entity_hurt_player";
+    
+    private final Optional<Damage> damage;
+
+    @JsonCreator
+    public EntityHurtPlayerConditions(
+        @JsonProperty("damage") Optional<Damage> damage) {
+        this.damage = damage;
+    }
+
+    public Optional<Damage> getDamage() {
+        return damage;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/EntityKilledPlayerConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/EntityKilledPlayerConditions.java
@@ -1,0 +1,31 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.DamageType;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+
+import java.util.Optional;
+
+public class EntityKilledPlayerConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:entity_killed_player";
+
+    private final Optional<Entity> entity;
+    private final Optional<DamageType> killingBlow;
+
+    @JsonCreator
+    public EntityKilledPlayerConditions(
+        @JsonProperty("entity") Optional<Entity> entity,
+        @JsonProperty("killing_blow") Optional<DamageType> killingBlow) {
+        this.entity = entity;
+        this.killingBlow = killingBlow;
+    }
+
+    public Optional<Entity> getEntity() {
+        return entity;
+    }
+
+    public Optional<DamageType> getKillingBlow() {
+        return killingBlow;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/FilledBucketConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/FilledBucketConditions.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Item;
+
+import java.util.Optional;
+
+public class FilledBucketConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:filled_bucket";
+
+    private final Optional<Item> item;
+
+    @JsonCreator
+    public FilledBucketConditions(
+        @JsonProperty("item") Optional<Item> item) {
+        this.item = item;
+    }
+
+    public Optional<Item> getItem() {
+        return item;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/FishingRodHookedConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/FishingRodHookedConditions.java
@@ -1,0 +1,38 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Item;
+
+import java.util.Optional;
+
+public class FishingRodHookedConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:fishing_rod_hooked";
+
+    private final Optional<Entity> entity;
+    private final Optional<Item> item;
+    private final Optional<Item> rod;
+
+    @JsonCreator
+    public FishingRodHookedConditions(
+        @JsonProperty("entity") Optional<Entity> entity,
+        @JsonProperty("item") Optional<Item> item,
+        @JsonProperty("rod") Optional<Item> rod) {
+        this.entity = entity;
+        this.item = item;
+        this.rod = rod;
+    }
+
+    public Optional<Entity> getEntity() {
+        return entity;
+    }
+
+    public Optional<Item> getItem() {
+        return item;
+    }
+
+    public Optional<Item> getRod() {
+        return rod;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/HeroOfTheVillageConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/HeroOfTheVillageConditions.java
@@ -1,0 +1,36 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.LocationBlock;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Fluid;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Location;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Position;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedDouble;
+
+import java.util.Optional;
+
+public class HeroOfTheVillageConditions extends Location implements Conditions {
+    public static final String TYPE_ID = "minecraft:hero_of_the_village";
+
+    private final Optional<Location> location;
+
+    @JsonCreator
+    public HeroOfTheVillageConditions(
+        @JsonProperty("biome") Optional<String> biome,
+        @JsonProperty("block") Optional<LocationBlock> block,
+        @JsonProperty("dimension") Optional<String> dimension,
+        @JsonProperty("feature") Optional<String> feature,
+        @JsonProperty("fluid") Optional<Fluid> fluid,
+        @JsonProperty("light") Optional<RangedDouble> light,
+        @JsonProperty("position") Optional<Position> position,
+        @JsonProperty("location") Optional<Location> location) {
+        super(biome, block, dimension, feature, fluid, light, position);
+
+        this.location = location;
+    }
+
+    public Optional<Location> getLocation() {
+        return location;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ImpossibleConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ImpossibleConditions.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+public class ImpossibleConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:impossible";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/InventoryChangedConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/InventoryChangedConditions.java
@@ -1,0 +1,32 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Item;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Slots;
+
+import java.util.List;
+import java.util.Optional;
+
+public class InventoryChangedConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:inventory_changed";
+
+    private final Optional<List<Item>> items;
+    private final Optional<Slots> slots;
+
+    @JsonCreator
+    public InventoryChangedConditions(
+        @JsonProperty("items") Optional<List<Item>> items,
+        @JsonProperty("slots") Optional<Slots> slots) {
+        this.items = items;
+        this.slots = slots;
+    }
+
+    public Optional<List<Item>> getItems() {
+        return items;
+    }
+
+    public Optional<Slots> getSlots() {
+        return slots;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ItemDurabilityChangedConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ItemDurabilityChangedConditions.java
@@ -1,0 +1,38 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Item;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+
+import java.util.Optional;
+
+public class ItemDurabilityChangedConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:item_durability_changed";
+
+    private final Optional<RangedInt> delta;
+    private final Optional<RangedInt> durability;
+    private final Optional<Item> item;
+
+    @JsonCreator
+    public ItemDurabilityChangedConditions(
+        @JsonProperty("delta") Optional<RangedInt> delta,
+        @JsonProperty("durability") Optional<RangedInt> durability,
+        @JsonProperty("item") Optional<Item> item) {
+        this.delta = delta;
+        this.durability = durability;
+        this.item = item;
+    }
+
+    public Optional<RangedInt> getDelta() {
+        return delta;
+    }
+
+    public Optional<RangedInt> getDurability() {
+        return durability;
+    }
+
+    public Optional<Item> getItem() {
+        return item;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/KilledByCrossbowConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/KilledByCrossbowConditions.java
@@ -1,0 +1,32 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+
+import java.util.List;
+import java.util.Optional;
+
+public class KilledByCrossbowConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:killed_by_crossbow";
+
+    private final Optional<RangedInt> uniqueEntityTypes;
+    private final Optional<List<Entity>> victims;
+
+    @JsonCreator
+    public KilledByCrossbowConditions(
+        @JsonProperty("unique_entity_types") Optional<RangedInt> uniqueEntityTypes,
+        @JsonProperty("victims") Optional<List<Entity>> victims) {
+        this.uniqueEntityTypes = uniqueEntityTypes;
+        this.victims = victims;
+    }
+
+    public Optional<RangedInt> getUniqueEntityTypes() {
+        return uniqueEntityTypes;
+    }
+
+    public Optional<List<Entity>> getVictims() {
+        return victims;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/LevitationConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/LevitationConditions.java
@@ -1,0 +1,31 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Distance;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+
+import java.util.Optional;
+
+public class LevitationConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:levitation";
+
+    private final Optional<Distance> distance;
+    private final Optional<RangedInt> duration;
+
+    @JsonCreator
+    public LevitationConditions(
+        @JsonProperty("distance") Optional<Distance> distance,
+        @JsonProperty("duration") Optional<RangedInt> duration) {
+        this.distance = distance;
+        this.duration = duration;
+    }
+
+    public Optional<Distance> getDistance() {
+        return distance;
+    }
+
+    public Optional<RangedInt> getDuration() {
+        return duration;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/LocationConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/LocationConditions.java
@@ -1,0 +1,36 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.LocationBlock;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Fluid;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Location;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Position;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedDouble;
+
+import java.util.Optional;
+
+public class LocationConditions extends Location implements Conditions {
+    public static final String TYPE_ID = "minecraft:location";
+
+    private final Optional<Location> location;
+
+    @JsonCreator
+    public LocationConditions(
+        @JsonProperty("biome") Optional<String> biome,
+        @JsonProperty("block") Optional<LocationBlock> block,
+        @JsonProperty("dimension") Optional<String> dimension,
+        @JsonProperty("feature") Optional<String> feature,
+        @JsonProperty("fluid") Optional<Fluid> fluid,
+        @JsonProperty("light") Optional<RangedDouble> light,
+        @JsonProperty("position") Optional<Position> position,
+        @JsonProperty("location") Optional<Location> location) {
+        super(biome, block, dimension, feature, fluid, light, position);
+
+        this.location = location;
+    }
+
+    public Optional<Location> getLocation() {
+        return location;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/NetherTravelConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/NetherTravelConditions.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Distance;
+
+import java.util.Optional;
+
+public class NetherTravelConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:nether_travel";
+
+    private final Optional<Distance> distance;
+
+    @JsonCreator
+    public NetherTravelConditions(
+        @JsonProperty("distance") Optional<Distance> distance) {
+        this.distance = distance;
+    }
+
+    public Optional<Distance> getDistance() {
+        return distance;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/PlacedBlockConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/PlacedBlockConditions.java
@@ -1,0 +1,46 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Location;
+import net.glowstone.datapack.loader.model.external.recipe.Item;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class PlacedBlockConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:placed_block";
+
+    private final Optional<String> block;
+    private final Optional<Item> item;
+    private final Optional<Location> location;
+    private final Optional<Map<String, String>> state;
+
+    @JsonCreator
+    public PlacedBlockConditions(
+        @JsonProperty("block") Optional<String> block,
+        @JsonProperty("item") Optional<Item> item,
+        @JsonProperty("location") Optional<Location> location,
+        @JsonProperty("state") Optional<Map<String, String>> state) {
+        this.block = block;
+        this.item = item;
+        this.location = location;
+        this.state = state;
+    }
+
+    public Optional<String> getBlock() {
+        return block;
+    }
+
+    public Optional<Item> getItem() {
+        return item;
+    }
+
+    public Optional<Location> getLocation() {
+        return location;
+    }
+
+    public Optional<Map<String, String>> getState() {
+        return state;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/PlayerHurtEntityConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/PlayerHurtEntityConditions.java
@@ -1,0 +1,31 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Damage;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+
+import java.util.Optional;
+
+public class PlayerHurtEntityConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:player_hurt_entity";
+
+    private final Optional<Damage> damage;
+    private final Optional<Entity> entity;
+
+    @JsonCreator
+    public PlayerHurtEntityConditions(
+        @JsonProperty("damage") Optional<Damage> damage,
+        @JsonProperty("entity") Optional<Entity> entity) {
+        this.damage = damage;
+        this.entity = entity;
+    }
+
+    public Optional<Damage> getDamage() {
+        return damage;
+    }
+
+    public Optional<Entity> getEntity() {
+        return entity;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/PlayerKilledEntityConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/PlayerKilledEntityConditions.java
@@ -1,0 +1,31 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.DamageType;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+
+import java.util.Optional;
+
+public class PlayerKilledEntityConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:player_killed_entity";
+
+    private final Optional<Entity> entity;
+    private final Optional<DamageType> killingBlow;
+
+    @JsonCreator
+    public PlayerKilledEntityConditions(
+        @JsonProperty("entity") Optional<Entity> entity,
+        @JsonProperty("killing_blow") Optional<DamageType> killingBlow) {
+        this.entity = entity;
+        this.killingBlow = killingBlow;
+    }
+
+    public Optional<Entity> getEntity() {
+        return entity;
+    }
+
+    public Optional<DamageType> getKillingBlow() {
+        return killingBlow;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/RecipeUnlockedConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/RecipeUnlockedConditions.java
@@ -1,0 +1,22 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class RecipeUnlockedConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:recipe_unlocked";
+
+    private final Optional<String> recipe;
+
+    @JsonCreator
+    public RecipeUnlockedConditions(
+        @JsonProperty("recipe") Optional<String> recipe) {
+        this.recipe = recipe;
+    }
+
+    public Optional<String> getRecipe() {
+        return recipe;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/SafelyHarvestHoneyConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/SafelyHarvestHoneyConditions.java
@@ -1,0 +1,31 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Block;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Item;
+
+import java.util.Optional;
+
+public class SafelyHarvestHoneyConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:safely_harvest_honey";
+
+    private final Optional<Block> block;
+    private final Optional<Item> item;
+
+    @JsonCreator
+    public SafelyHarvestHoneyConditions(
+        @JsonProperty("block") Optional<Block> block,
+        @JsonProperty("item") Optional<Item> item) {
+        this.block = block;
+        this.item = item;
+    }
+
+    public Optional<Block> getBlock() {
+        return block;
+    }
+
+    public Optional<Item> getItem() {
+        return item;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ShotCrossbowConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/ShotCrossbowConditions.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.recipe.Item;
+
+import java.util.Optional;
+
+public class ShotCrossbowConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:shot_crossbow";
+
+    private final Optional<Item> item;
+
+    @JsonCreator
+    public ShotCrossbowConditions(
+        @JsonProperty("item") Optional<Item> item) {
+        this.item = item;
+    }
+
+    public Optional<Item> getItem() {
+        return item;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/SleptInBedConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/SleptInBedConditions.java
@@ -1,0 +1,36 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Fluid;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Location;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.LocationBlock;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Position;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedDouble;
+
+import java.util.Optional;
+
+public class SleptInBedConditions extends Location implements Conditions {
+    public static final String TYPE_ID = "minecraft:slept_in_bed";
+
+    private final Optional<Location> location;
+
+    @JsonCreator
+    public SleptInBedConditions(
+        @JsonProperty("biome") Optional<String> biome,
+        @JsonProperty("block") Optional<LocationBlock> block,
+        @JsonProperty("dimension") Optional<String> dimension,
+        @JsonProperty("feature") Optional<String> feature,
+        @JsonProperty("fluid") Optional<Fluid> fluid,
+        @JsonProperty("light") Optional<RangedDouble> light,
+        @JsonProperty("position") Optional<Position> position,
+        @JsonProperty("location") Optional<Location> location) {
+        super(biome, block, dimension, feature, fluid, light, position);
+
+        this.location = location;
+    }
+
+    public Optional<Location> getLocation() {
+        return location;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/SlideDownBlockConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/SlideDownBlockConditions.java
@@ -1,0 +1,22 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class SlideDownBlockConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:slide_down_block";
+
+    private final Optional<String> block;
+
+    @JsonCreator
+    public SlideDownBlockConditions(
+        @JsonProperty("block") Optional<String> block) {
+        this.block = block;
+    }
+
+    public Optional<String> getBlock() {
+        return block;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/SummonedEntityConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/SummonedEntityConditions.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+
+import java.util.Optional;
+
+public class SummonedEntityConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:summoned_entity";
+
+    private final Optional<Entity> entity;
+
+    @JsonCreator
+    public SummonedEntityConditions(
+        @JsonProperty("entity") Optional<Entity> entity) {
+        this.entity = entity;
+    }
+
+    public Optional<Entity> getEntity() {
+        return entity;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/TameAnimalConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/TameAnimalConditions.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+
+import java.util.Optional;
+
+public class TameAnimalConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:tame_animal";
+
+    private final Optional<Entity> entity;
+
+    @JsonCreator
+    public TameAnimalConditions(
+        @JsonProperty("entity") Optional<Entity> entity) {
+        this.entity = entity;
+    }
+
+    public Optional<Entity> getEntity() {
+        return entity;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/TickConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/TickConditions.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+public class TickConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:tick";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/UsedEnderEyeConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/UsedEnderEyeConditions.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedDoubleInt;
+
+import java.util.Optional;
+
+public class UsedEnderEyeConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:used_ender_eye";
+
+    private final Optional<RangedDoubleInt> distance;
+
+    @JsonCreator
+    public UsedEnderEyeConditions(
+        @JsonProperty("distance") Optional<RangedDoubleInt> distance) {
+        this.distance = distance;
+    }
+
+    public Optional<RangedDoubleInt> getDistance() {
+        return distance;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/UsedTotemConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/UsedTotemConditions.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.recipe.Item;
+
+import java.util.Optional;
+
+public class UsedTotemConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:used_totem";
+
+    private final Optional<Item> item;
+
+    @JsonCreator
+    public UsedTotemConditions(
+        @JsonProperty("item") Optional<Item> item) {
+        this.item = item;
+    }
+
+    public Optional<Item> getItem() {
+        return item;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/VillagerTradeConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/VillagerTradeConditions.java
@@ -1,0 +1,31 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+import net.glowstone.datapack.loader.model.external.recipe.Item;
+
+import java.util.Optional;
+
+public class VillagerTradeConditions implements Conditions {
+    public static final String TYPE_ID = "minecraft:villager_trade";
+
+    private final Optional<Item> item;
+    private final Optional<Entity> villager;
+
+    @JsonCreator
+    public VillagerTradeConditions(
+        @JsonProperty("item") Optional<Item> item,
+        @JsonProperty("villager") Optional<Entity> villager) {
+        this.item = item;
+        this.villager = villager;
+    }
+
+    public Optional<Item> getItem() {
+        return item;
+    }
+
+    public Optional<Entity> getVillager() {
+        return villager;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/VoluntaryExileConditions.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/VoluntaryExileConditions.java
@@ -1,0 +1,36 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Fluid;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Location;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.LocationBlock;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Position;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedDouble;
+
+import java.util.Optional;
+
+public class VoluntaryExileConditions extends Location implements Conditions {
+    public static final String TYPE_ID = "minecraft:voluntary_exile";
+
+    private final Optional<Location> location;
+
+    @JsonCreator
+    public VoluntaryExileConditions(
+        @JsonProperty("biome") Optional<String> biome,
+        @JsonProperty("block") Optional<LocationBlock> block,
+        @JsonProperty("dimension") Optional<String> dimension,
+        @JsonProperty("feature") Optional<String> feature,
+        @JsonProperty("fluid") Optional<Fluid> fluid,
+        @JsonProperty("light") Optional<RangedDouble> light,
+        @JsonProperty("position") Optional<Position> position,
+        @JsonProperty("location") Optional<Location> location) {
+        super(biome, block, dimension, feature, fluid, light, position);
+
+        this.location = location;
+    }
+
+    public Optional<Location> getLocation() {
+        return location;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Advancement.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Advancement.java
@@ -1,0 +1,54 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class Advancement {
+    @JsonCreator
+    public static Advancement fromJson(JsonNode rootNode) throws JsonMappingException {
+        if (rootNode.isBoolean()) {
+            return createWithEnabled(rootNode.asBoolean());
+        } else if (rootNode.isObject()) {
+            Map<String, Boolean> criteria = new HashMap<>();
+            for (Map.Entry<String, JsonNode> entry : ImmutableList.copyOf(rootNode.fields())) {
+                if (entry.getValue().isBoolean()) {
+                    criteria.put(entry.getKey(), entry.getValue().asBoolean());
+                }
+            }
+            if (criteria.size() == rootNode.size()) {
+                return createWithCriteria(criteria);
+            }
+        }
+        throw new JsonMappingException(null, "Cannot create Advancement");
+    }
+
+    public static Advancement createWithEnabled(boolean advancement) {
+        return new Advancement(Optional.of(advancement), Optional.empty());
+    }
+
+    public static Advancement createWithCriteria(Map<String, Boolean> criteria) {
+        return new Advancement(Optional.empty(), Optional.of(criteria));
+    }
+
+    private final Optional<Boolean> advancement;
+    private final Optional<Map<String, Boolean>> criteria;
+
+    private Advancement(Optional<Boolean> advancement, Optional<Map<String, Boolean>> criteria) {
+        this.advancement = advancement;
+        this.criteria = criteria;
+    }
+
+    public Optional<Boolean> getAdvancement() {
+        return advancement;
+    }
+
+    public Optional<Map<String, Boolean>> getCriteria() {
+        return criteria;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Block.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Block.java
@@ -1,0 +1,28 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class Block {
+    private final Optional<String> block;
+    private final Optional<String> tag;
+
+    @JsonCreator
+    public Block(
+        @JsonProperty("block") Optional<String> block,
+        @JsonProperty("tag") Optional<String> tag) {
+        this.block = block;
+        this.tag = tag;
+    }
+
+    public Optional<String> getBlock() {
+        return block;
+    }
+
+    public Optional<String> getTag() {
+        return tag;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Damage.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Damage.java
@@ -1,0 +1,48 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class Damage {
+    private final Optional<Boolean> blocked;
+    private final Optional<RangedDouble> dealt;
+    private final Optional<Entity> sourceEntity;
+    private final Optional<RangedDouble> taken;
+    private final Optional<DamageType> type;
+
+    @JsonCreator
+    public Damage(
+        @JsonProperty("blocked") Optional<Boolean> blocked,
+        @JsonProperty("dealt") Optional<RangedDouble> dealt,
+        @JsonProperty("source_entity") Optional<Entity> sourceEntity,
+        @JsonProperty("taken") Optional<RangedDouble> taken,
+        @JsonProperty("type") Optional<DamageType> type) {
+        this.blocked = blocked;
+        this.dealt = dealt;
+        this.sourceEntity = sourceEntity;
+        this.taken = taken;
+        this.type = type;
+    }
+
+    public Optional<Boolean> getBlocked() {
+        return blocked;
+    }
+
+    public Optional<RangedDouble> getDealt() {
+        return dealt;
+    }
+
+    public Optional<Entity> getSourceEntity() {
+        return sourceEntity;
+    }
+
+    public Optional<RangedDouble> getTaken() {
+        return taken;
+    }
+
+    public Optional<DamageType> getType() {
+        return type;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/DamageType.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/DamageType.java
@@ -1,0 +1,83 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class DamageType {
+    private final Optional<Boolean> bypassesArmor;
+    private final Optional<Boolean> bypassesInvulnerability;
+    private final Optional<Boolean> bypassesMagic;
+    private final Optional<Entity> directEntity;
+    private final Optional<Boolean> isExplosion;
+    private final Optional<Boolean> isFire;
+    private final Optional<Boolean> isMagic;
+    private final Optional<Boolean> isProjectile;
+    private final Optional<Boolean> isLightning;
+    private final Optional<Entity> sourceEntity;
+
+    @JsonCreator
+    public DamageType(
+        @JsonProperty("bypasses_armor") Optional<Boolean> bypassesArmor,
+        @JsonProperty("bypasses_invulnerability") Optional<Boolean> bypassesInvulnerability,
+        @JsonProperty("bypasses_magic") Optional<Boolean> bypassesMagic,
+        @JsonProperty("direct_entity") Optional<Entity> directEntity,
+        @JsonProperty("is_explosion") Optional<Boolean> isExplosion,
+        @JsonProperty("is_fire") Optional<Boolean> isFire,
+        @JsonProperty("is_magic") Optional<Boolean> isMagic,
+        @JsonProperty("is_projectile") Optional<Boolean> isProjectile,
+        @JsonProperty("is_lightning") Optional<Boolean> isLightning,
+        @JsonProperty("source_entry") Optional<Entity> sourceEntity) {
+        this.bypassesArmor = bypassesArmor;
+        this.bypassesInvulnerability = bypassesInvulnerability;
+        this.bypassesMagic = bypassesMagic;
+        this.directEntity = directEntity;
+        this.isExplosion = isExplosion;
+        this.isFire = isFire;
+        this.isMagic = isMagic;
+        this.isProjectile = isProjectile;
+        this.isLightning = isLightning;
+        this.sourceEntity = sourceEntity;
+    }
+
+    public Optional<Boolean> getBypassesArmor() {
+        return bypassesArmor;
+    }
+
+    public Optional<Boolean> getBypassesInvulnerability() {
+        return bypassesInvulnerability;
+    }
+
+    public Optional<Boolean> getBypassesMagic() {
+        return bypassesMagic;
+    }
+
+    public Optional<Entity> getDirectEntity() {
+        return directEntity;
+    }
+
+    public Optional<Boolean> getIsExplosion() {
+        return isExplosion;
+    }
+
+    public Optional<Boolean> getIsFire() {
+        return isFire;
+    }
+
+    public Optional<Boolean> getIsMagic() {
+        return isMagic;
+    }
+
+    public Optional<Boolean> getIsProjectile() {
+        return isProjectile;
+    }
+
+    public Optional<Boolean> getIsLightning() {
+        return isLightning;
+    }
+
+    public Optional<Entity> getSourceEntity() {
+        return sourceEntity;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Distance.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Distance.java
@@ -1,0 +1,48 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class Distance {
+    private final Optional<RangedDouble> absolute;
+    private final Optional<RangedDouble> horizontal;
+    private final Optional<RangedDouble> x;
+    private final Optional<RangedDouble> y;
+    private final Optional<RangedDouble> z;
+
+    @JsonCreator
+    public Distance(
+        @JsonProperty("absolute") Optional<RangedDouble> absolute,
+        @JsonProperty("horizontal") Optional<RangedDouble> horizontal,
+        @JsonProperty("x") Optional<RangedDouble> x,
+        @JsonProperty("y") Optional<RangedDouble> y,
+        @JsonProperty("z") Optional<RangedDouble> z) {
+        this.absolute = absolute;
+        this.horizontal = horizontal;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    public Optional<RangedDouble> getAbsolute() {
+        return absolute;
+    }
+
+    public Optional<RangedDouble> getHorizontal() {
+        return horizontal;
+    }
+
+    public Optional<RangedDouble> getX() {
+        return x;
+    }
+
+    public Optional<RangedDouble> getY() {
+        return y;
+    }
+
+    public Optional<RangedDouble> getZ() {
+        return z;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Effect.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Effect.java
@@ -1,0 +1,27 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class Effect {
+    private final Optional<RangedInt> amplifier;
+    private final Optional<RangedInt> duration;
+
+    @JsonCreator
+    public Effect(
+        @JsonProperty("amplifier") Optional<RangedInt> amplifier,
+        @JsonProperty("duration") Optional<RangedInt> duration) {
+        this.amplifier = amplifier;
+        this.duration = duration;
+    }
+
+    public Optional<RangedInt> getAmplifier() {
+        return amplifier;
+    }
+
+    public Optional<RangedInt> getDuration() {
+        return duration;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Enchantment.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Enchantment.java
@@ -1,0 +1,27 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class Enchantment {
+    private final Optional<String> enchantment;
+    private final Optional<RangedInt> levels;
+
+    @JsonCreator
+    public Enchantment(
+            @JsonProperty("enchantment") Optional<String> enchantment,
+            @JsonProperty("levels") Optional<RangedInt> levels) {
+        this.enchantment = enchantment;
+        this.levels = levels;
+    }
+
+    public Optional<String> getEnchantment() {
+        return enchantment;
+    }
+
+    public Optional<RangedInt> getLevels() {
+        return levels;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Entity.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Entity.java
@@ -1,0 +1,126 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class Entity {
+    public static class Flags {
+        private final Optional<Boolean> onFire;
+        private final Optional<Boolean> sneaking;
+        private final Optional<Boolean> sprinting;
+        private final Optional<Boolean> swimming;
+        private final Optional<Boolean> baby;
+
+        @JsonCreator
+        public Flags(
+            @JsonProperty("is_on_fire") Optional<Boolean> onFire,
+            @JsonProperty("is_sneaking") Optional<Boolean> sneaking,
+            @JsonProperty("is_sprinting") Optional<Boolean> sprinting,
+            @JsonProperty("is_swimming") Optional<Boolean> swimming,
+            @JsonProperty("is_baby") Optional<Boolean> baby) {
+            this.onFire = onFire;
+            this.sneaking = sneaking;
+            this.sprinting = sprinting;
+            this.swimming = swimming;
+            this.baby = baby;
+        }
+
+        public Optional<Boolean> getOnFire() {
+            return onFire;
+        }
+
+        public Optional<Boolean> getSneaking() {
+            return sneaking;
+        }
+
+        public Optional<Boolean> getSprinting() {
+            return sprinting;
+        }
+
+        public Optional<Boolean> getSwimming() {
+            return swimming;
+        }
+
+        public Optional<Boolean> getBaby() {
+            return baby;
+        }
+    }
+
+    private final Optional<String> catType;
+    private final Optional<Distance> distance;
+    private final Optional<Map<String, StatusEffect>> effects;
+    private final Optional<Equipment> equipment;
+    private final Optional<Flags> flags;
+    private final Optional<Location> location;
+    private final Optional<String> nbt;
+    private final Optional<Player> player;
+    private final Optional<String> team;
+    private final Optional<String> type;
+
+    @JsonCreator
+    public Entity(
+        @JsonProperty("catType") Optional<String> catType,
+        @JsonProperty("distance") Optional<Distance> distance,
+        @JsonProperty("effects") Optional<Map<String, StatusEffect>> effects,
+        @JsonProperty("equipment") Optional<Equipment> equipment,
+        @JsonProperty("flags") Optional<Flags> flags,
+        @JsonProperty("location") Optional<Location> location,
+        @JsonProperty("nbt") Optional<String> nbt,
+        @JsonProperty("player") Optional<Player> player,
+        @JsonProperty("team") Optional<String> team,
+        @JsonProperty("type") Optional<String> type) {
+        this.catType = catType;
+        this.distance = distance;
+        this.effects = effects;
+        this.equipment = equipment;
+        this.flags = flags;
+        this.location = location;
+        this.nbt = nbt;
+        this.player = player;
+        this.team = team;
+        this.type = type;
+    }
+
+    public Optional<String> getCatType() {
+        return catType;
+    }
+
+    public Optional<Distance> getDistance() {
+        return distance;
+    }
+
+    public Optional<Map<String, StatusEffect>> getEffects() {
+        return effects;
+    }
+
+    public Optional<Equipment> getEquipment() {
+        return equipment;
+    }
+
+    public Optional<Flags> getFlags() {
+        return flags;
+    }
+
+    public Optional<Location> getLocation() {
+        return location;
+    }
+
+    public Optional<String> getNbt() {
+        return nbt;
+    }
+
+    public Optional<Player> getPlayer() {
+        return player;
+    }
+
+    public Optional<String> getTeam() {
+        return team;
+    }
+
+    public Optional<String> getType() {
+        return type;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Equipment.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Equipment.java
@@ -1,0 +1,55 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class Equipment {
+    private final Optional<Item> mainhand;
+    private final Optional<Item> offhand;
+    private final Optional<Item> head;
+    private final Optional<Item> chest;
+    private final Optional<Item> legs;
+    private final Optional<Item> feet;
+
+    @JsonCreator
+    public Equipment(
+        @JsonProperty("mainhand") Optional<Item> mainhand,
+        @JsonProperty("offhand") Optional<Item> offhand,
+        @JsonProperty("head") Optional<Item> head,
+        @JsonProperty("chest") Optional<Item> chest,
+        @JsonProperty("legs") Optional<Item> legs,
+        @JsonProperty("feet") Optional<Item> feet) {
+        this.mainhand = mainhand;
+        this.offhand = offhand;
+        this.head = head;
+        this.chest = chest;
+        this.legs = legs;
+        this.feet = feet;
+    }
+
+    public Optional<Item> getMainhand() {
+        return mainhand;
+    }
+
+    public Optional<Item> getOffhand() {
+        return offhand;
+    }
+
+    public Optional<Item> getHead() {
+        return head;
+    }
+
+    public Optional<Item> getChest() {
+        return chest;
+    }
+
+    public Optional<Item> getLegs() {
+        return legs;
+    }
+
+    public Optional<Item> getFeet() {
+        return feet;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Fluid.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Fluid.java
@@ -1,0 +1,35 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class Fluid {
+    private final Optional<String> fluid;
+    private final Optional<String> tag;
+    private final Map<String, PropertyValue<?>> state;
+
+    @JsonCreator
+    public Fluid(
+        @JsonProperty("fluid") Optional<String> fluid,
+        @JsonProperty("tag") Optional<String> tag,
+        @JsonProperty("state") Map<String, PropertyValue<?>> state) {
+        this.fluid = fluid;
+        this.tag = tag;
+        this.state = state;
+    }
+
+    public Optional<String> getFluid() {
+        return fluid;
+    }
+
+    public Optional<String> getTag() {
+        return tag;
+    }
+
+    public Map<String, PropertyValue<?>> getState() {
+        return state;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Item.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Item.java
@@ -1,0 +1,70 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Optional;
+
+public class Item {
+    private final Optional<RangedInt> count;
+    private final Optional<RangedInt> durability;
+    private final Optional<List<Enchantment>> enchantments;
+    private final Optional<List<Enchantment>> storedEnchantments;
+    private final Optional<ItemId> item;
+    private final Optional<String> nbt;
+    private final Optional<String> potion;
+    private final Optional<String> tag;
+
+    @JsonCreator
+    public Item(
+            @JsonProperty("count") Optional<RangedInt> count,
+            @JsonProperty("durability") Optional<RangedInt> durability,
+            @JsonProperty("enchantments") Optional<List<Enchantment>> enchantments,
+            @JsonProperty("stored_enchantments") Optional<List<Enchantment>> storedEnchantments,
+            @JsonProperty("item") Optional<ItemId> item,
+            @JsonProperty("nbt") Optional<String> nbt,
+            @JsonProperty("potion") Optional<String> potion,
+            @JsonProperty("tag") Optional<String> tag) {
+        this.count = count;
+        this.durability = durability;
+        this.enchantments = enchantments;
+        this.storedEnchantments = storedEnchantments;
+        this.item = item;
+        this.nbt = nbt;
+        this.potion = potion;
+        this.tag = tag;
+    }
+
+    public Optional<RangedInt> getCount() {
+        return count;
+    }
+
+    public Optional<RangedInt> getDurability() {
+        return durability;
+    }
+
+    public Optional<List<Enchantment>> getEnchantments() {
+        return enchantments;
+    }
+
+    public Optional<List<Enchantment>> getStoredEnchantments() {
+        return storedEnchantments;
+    }
+
+    public Optional<ItemId> getItem() {
+        return item;
+    }
+
+    public Optional<String> getNbt() {
+        return nbt;
+    }
+
+    public Optional<String> getPotion() {
+        return potion;
+    }
+
+    public Optional<String> getTag() {
+        return tag;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/ItemId.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/ItemId.java
@@ -1,0 +1,37 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Optional;
+
+public class ItemId {
+    @JsonCreator
+    public static ItemId fromJson(JsonNode rootNode) throws JsonMappingException {
+        if (rootNode.isTextual()) {
+            return new ItemId(Optional.of(rootNode.asText()));
+        } else if (rootNode.isObject()) {
+            JsonNode itemNode = rootNode.get("item");
+            if (itemNode != null && itemNode.isTextual()) {
+                return new ItemId(Optional.of(itemNode.asText()));
+            } else if (itemNode == null || itemNode.isNull()) {
+                return new ItemId(Optional.empty());
+            }
+        } else if (rootNode.isNull()) {
+            return new ItemId(Optional.empty());
+        }
+        throw new JsonMappingException(null, "Cannot create ItemId");
+    }
+
+    private final Optional<String> item;
+
+    public ItemId(Optional<String> item) {
+        this.item = item;
+    }
+
+    public Optional<String> getItem() {
+        return item;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Location.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Location.java
@@ -1,0 +1,62 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class Location {
+    private final Optional<String> biome;
+    private final Optional<LocationBlock> block;
+    private final Optional<String> dimension;
+    private final Optional<String> feature;
+    private final Optional<Fluid> fluid;
+    private final Optional<RangedDouble> light;
+    private final Optional<Position> position;
+
+    @JsonCreator
+    public Location(
+        @JsonProperty("biome") Optional<String> biome,
+        @JsonProperty("block") Optional<LocationBlock> block,
+        @JsonProperty("dimension") Optional<String> dimension,
+        @JsonProperty("feature") Optional<String> feature,
+        @JsonProperty("fluid") Optional<Fluid> fluid,
+        @JsonProperty("light") Optional<RangedDouble> light,
+        @JsonProperty("position") Optional<Position> position) {
+        this.biome = biome;
+        this.block = block;
+        this.dimension = dimension;
+        this.feature = feature;
+        this.fluid = fluid;
+        this.light = light;
+        this.position = position;
+    }
+
+    public Optional<String> getBiome() {
+        return biome;
+    }
+
+    public Optional<LocationBlock> getBlock() {
+        return block;
+    }
+
+    public Optional<String> getDimension() {
+        return dimension;
+    }
+
+    public Optional<String> getFeature() {
+        return feature;
+    }
+
+    public Optional<Fluid> getFluid() {
+        return fluid;
+    }
+
+    public Optional<RangedDouble> getLight() {
+        return light;
+    }
+
+    public Optional<Position> getPosition() {
+        return position;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/LocationBlock.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/LocationBlock.java
@@ -1,0 +1,31 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class LocationBlock extends Block {
+    private final Optional<String> nbt;
+    private final Map<String, PropertyValue<?>> state;
+
+    @JsonCreator
+    public LocationBlock(
+        @JsonProperty("block") Optional<String> block,
+        @JsonProperty("tag") Optional<String> tag,
+        @JsonProperty("nbt") Optional<String> nbt,
+        @JsonProperty("state") Map<String, PropertyValue<?>> state) {
+        super(block, tag);
+        this.nbt = nbt;
+        this.state = state;
+    }
+
+    public Optional<String> getNbt() {
+        return nbt;
+    }
+
+    public Map<String, PropertyValue<?>> getState() {
+        return state;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Player.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Player.java
@@ -1,0 +1,50 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class Player {
+    private final Optional<Map<String, Advancement>> advancements;
+    private final Optional<String> gamemode;
+    private final Optional<RangedInt> level;
+    private final Optional<Map<String, Boolean>> recipes;
+    private final Optional<List<Stats>> stats;
+
+    @JsonCreator
+    public Player(
+        @JsonProperty("advancements") Optional<Map<String, Advancement>> advancements,
+        @JsonProperty("gamemode") Optional<String> gamemode,
+        @JsonProperty("level") Optional<RangedInt> level,
+        @JsonProperty("recipes") Optional<Map<String, Boolean>> recipes,
+        @JsonProperty("stats") Optional<List<Stats>> stats) {
+        this.advancements = advancements;
+        this.gamemode = gamemode;
+        this.level = level;
+        this.recipes = recipes;
+        this.stats = stats;
+    }
+
+    public Optional<Map<String, Advancement>> getAdvancements() {
+        return advancements;
+    }
+
+    public Optional<String> getGamemode() {
+        return gamemode;
+    }
+
+    public Optional<RangedInt> getLevel() {
+        return level;
+    }
+
+    public Optional<Map<String, Boolean>> getRecipes() {
+        return recipes;
+    }
+
+    public Optional<List<Stats>> getStats() {
+        return stats;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Position.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Position.java
@@ -1,0 +1,34 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class Position {
+    private final Optional<RangedDouble> x;
+    private final Optional<RangedDouble> y;
+    private final Optional<RangedDouble> z;
+
+    @JsonCreator
+    public Position(
+        @JsonProperty("x") Optional<RangedDouble> x,
+        @JsonProperty("y") Optional<RangedDouble> y,
+        @JsonProperty("z") Optional<RangedDouble> z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    public Optional<RangedDouble> getX() {
+        return x;
+    }
+
+    public Optional<RangedDouble> getY() {
+        return y;
+    }
+
+    public Optional<RangedDouble> getZ() {
+        return z;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/PropertyValue.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/PropertyValue.java
@@ -1,0 +1,31 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class PropertyValue<T> {
+    @JsonCreator
+    public static PropertyValue<?> fromJson(JsonNode rootNode) throws JsonMappingException {
+        if (rootNode.isBoolean()) {
+            return new PropertyValue<>(rootNode.asBoolean());
+        } else if (rootNode.isInt()) {
+            return new PropertyValue<>(rootNode.asInt());
+        } else if (rootNode.isTextual()) {
+            return new PropertyValue<>(rootNode.asText());
+        } else if (rootNode.isObject()) {
+            return new PropertyValue<>(RangedInt.fromJson(rootNode));
+        }
+        throw new JsonMappingException(null, "Cannot create PropertyValue");
+    }
+
+    private final T value;
+
+    public PropertyValue(T value) {
+        this.value = value;
+    }
+
+    public T getValue() {
+        return value;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/RangedDouble.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/RangedDouble.java
@@ -1,0 +1,39 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+
+import static net.glowstone.datapack.loader.jackson.JsonNodeHandling.valueAsDouble;
+
+public class RangedDouble {
+    @JsonCreator
+    public static RangedDouble fromJson(JsonNode rootNode) throws JsonMappingException {
+        if (rootNode.isDouble()) {
+            OptionalDouble value = OptionalDouble.of(rootNode.asDouble());
+            return new RangedDouble(value, value);
+        } else if (rootNode.isObject()) {
+            return new RangedDouble(valueAsDouble(rootNode, "min"), valueAsDouble(rootNode, "max"));
+        }
+        throw new JsonMappingException(null, "Cannot create RangedDouble.");
+    }
+
+    private final OptionalDouble minValue;
+    private final OptionalDouble maxValue;
+
+    public RangedDouble(OptionalDouble minValue, OptionalDouble maxValue) {
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+    }
+
+    public OptionalDouble getMinValue() {
+        return minValue;
+    }
+
+    public OptionalDouble getMaxValue() {
+        return maxValue;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/RangedDoubleInt.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/RangedDoubleInt.java
@@ -1,0 +1,52 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+
+import static net.glowstone.datapack.loader.jackson.JsonNodeHandling.valueAsDouble;
+
+public class RangedDoubleInt {
+    @JsonCreator
+    public static RangedDoubleInt fromJson(JsonNode rootNode) throws JsonMappingException {
+        if (rootNode.isInt()) {
+            int value = rootNode.asInt();
+            return forStaticValue(value);
+        } else if (rootNode.isObject()) {
+            OptionalDouble min = valueAsDouble(rootNode, "min");
+            OptionalDouble max = valueAsDouble(rootNode, "max");
+            if (min.isPresent() && max.isPresent()) {
+                return forRangedValue(min.getAsDouble(), max.getAsDouble());
+            }
+        }
+        throw new JsonMappingException(null, "Cannot create RangedDouble.");
+    }
+
+    public static RangedDoubleInt forStaticValue(int staticValue) {
+        return new RangedDoubleInt(OptionalInt.of(staticValue), Optional.empty());
+    }
+
+    public static RangedDoubleInt forRangedValue(double min, double max) {
+        return new RangedDoubleInt(OptionalInt.empty(), Optional.of(new RangedDouble(OptionalDouble.of(min), OptionalDouble.of(max))));
+    }
+
+    private final OptionalInt staticValue;
+    private final Optional<RangedDouble> rangedValue;
+
+    private RangedDoubleInt(OptionalInt staticValue, Optional<RangedDouble> rangedValue) {
+        this.staticValue = staticValue;
+        this.rangedValue = rangedValue;
+    }
+
+    public OptionalInt getStaticValue() {
+        return staticValue;
+    }
+
+    public Optional<RangedDouble> getRangedValue() {
+        return rangedValue;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/RangedInt.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/RangedInt.java
@@ -1,0 +1,45 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.math.DoubleMath;
+
+import java.util.OptionalInt;
+
+import static net.glowstone.datapack.loader.jackson.JsonNodeHandling.valueAsInt;
+
+public class RangedInt {
+    @JsonCreator
+    public static RangedInt fromJson(JsonNode rootNode) throws JsonMappingException {
+        if (rootNode.isInt()) {
+            OptionalInt value = OptionalInt.of(rootNode.asInt());
+            return new RangedInt(value, value);
+        } else if (rootNode.isDouble()) {
+            double value = rootNode.asDouble();
+            if (DoubleMath.isMathematicalInteger(value)) {
+                OptionalInt intValue = OptionalInt.of((int)value);
+                return new RangedInt(intValue, intValue);
+            }
+        } else if (rootNode.isObject()) {
+            return new RangedInt(valueAsInt(rootNode, "min"), valueAsInt(rootNode, "max"));
+        }
+        throw new JsonMappingException(null, "Cannot create RangedInt.");
+    }
+
+    private final OptionalInt minValue;
+    private final OptionalInt maxValue;
+
+    public RangedInt(OptionalInt minValue, OptionalInt maxValue) {
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+    }
+
+    public OptionalInt getMinValue() {
+        return minValue;
+    }
+
+    public OptionalInt getMaxValue() {
+        return maxValue;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Slots.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Slots.java
@@ -1,0 +1,34 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class Slots {
+    private final Optional<RangedInt> empty;
+    private final Optional<RangedInt> full;
+    private final Optional<RangedInt> occupied;
+
+    @JsonCreator
+    public Slots(
+        @JsonProperty("empty") Optional<RangedInt> empty,
+        @JsonProperty("full") Optional<RangedInt> full,
+        @JsonProperty("occupied") Optional<RangedInt> occupied) {
+        this.empty = empty;
+        this.full = full;
+        this.occupied = occupied;
+    }
+
+    public Optional<RangedInt> getEmpty() {
+        return empty;
+    }
+
+    public Optional<RangedInt> getFull() {
+        return full;
+    }
+
+    public Optional<RangedInt> getOccupied() {
+        return occupied;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Stats.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/Stats.java
@@ -1,0 +1,34 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class Stats {
+    private final Optional<String> type;
+    private final Optional<String> stat;
+    private final Optional<RangedInt> value;
+
+    @JsonCreator
+    public Stats(
+        @JsonProperty("type") Optional<String> type,
+        @JsonProperty("stat") Optional<String> stat,
+        @JsonProperty("value") Optional<RangedInt> value) {
+        this.type = type;
+        this.stat = stat;
+        this.value = value;
+    }
+
+    public Optional<String> getType() {
+        return type;
+    }
+
+    public Optional<String> getStat() {
+        return stat;
+    }
+
+    public Optional<RangedInt> getValue() {
+        return value;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/StatusEffect.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/advancement/condition/prop/StatusEffect.java
@@ -1,0 +1,27 @@
+package net.glowstone.datapack.loader.model.external.advancement.condition.prop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class StatusEffect {
+    private final Optional<RangedInt> amplifier;
+    private final Optional<RangedInt> duration;
+
+    @JsonCreator
+    public StatusEffect(
+        @JsonProperty("amplifier") Optional<RangedInt> amplifier,
+        @JsonProperty("duration") Optional<RangedInt> duration) {
+        this.amplifier = amplifier;
+        this.duration = duration;
+    }
+
+    public Optional<RangedInt> getAmplifier() {
+        return amplifier;
+    }
+
+    public Optional<RangedInt> getDuration() {
+        return duration;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/function/Function.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/function/Function.java
@@ -1,0 +1,15 @@
+package net.glowstone.datapack.loader.model.external.function;
+
+import java.util.List;
+
+public class Function {
+    private final List<String> commands;
+
+    public Function(List<String> commands) {
+        this.commands = commands;
+    }
+
+    public List<String> getCommands() {
+        return commands;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/LootTable.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/LootTable.java
@@ -1,0 +1,48 @@
+package net.glowstone.datapack.loader.model.external.loottable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.function.Function;
+
+import java.util.List;
+import java.util.Optional;
+
+public class LootTable {
+    public enum Type {
+        @JsonProperty("minecraft:empty") EMPTY,
+        @JsonProperty("minecraft:entity") ENTITY,
+        @JsonProperty("minecraft:block") BLOCK,
+        @JsonProperty("minecraft:chest") CHEST,
+        @JsonProperty("minecraft:fishing") FISHING,
+        @JsonProperty("minecraft:gift") GIFT,
+        @JsonProperty("minecraft:advancement_reward") ADVANCEMENT_REWARD,
+        @JsonProperty("minecraft:barter") BARTER,
+        @JsonProperty("minecraft:generic") GENERIC,
+        }
+
+    private final Optional<Type> type;
+    private final List<Pool> pools;
+    private final List<Function> functions;
+
+    @JsonCreator
+    public LootTable(
+        @JsonProperty("type") Optional<Type> type,
+        @JsonProperty("pools") List<Pool> pools,
+        @JsonProperty("functions") List<Function> functions) {
+        this.type = type;
+        this.pools = pools;
+        this.functions = functions;
+    }
+
+    public Optional<Type> getType() {
+        return type;
+    }
+
+    public List<Pool> getPools() {
+        return pools;
+    }
+
+    public List<Function> getFunctions() {
+        return functions;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/Pool.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/Pool.java
@@ -1,0 +1,52 @@
+package net.glowstone.datapack.loader.model.external.loottable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+import net.glowstone.datapack.loader.model.external.loottable.entry.PoolEntry;
+import net.glowstone.datapack.loader.model.external.loottable.function.Function;
+
+import java.util.List;
+
+public class Pool {
+    private final List<Condition> conditions;
+    private final List<Function> functions;
+    private final RangedInt rolls;
+    private final RangedInt bonusRolls;
+    private final List<PoolEntry> entries;
+
+    @JsonCreator
+    public Pool(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("functions") List<Function> functions,
+        @JsonProperty("rolls") RangedInt rolls,
+        @JsonProperty("bonusRolls") RangedInt bonusRolls,
+        @JsonProperty("entries") List<PoolEntry> entries) {
+        this.conditions = conditions;
+        this.functions = functions;
+        this.rolls = rolls;
+        this.bonusRolls = bonusRolls;
+        this.entries = entries;
+    }
+
+    public List<Condition> getConditions() {
+        return conditions;
+    }
+
+    public List<Function> getFunctions() {
+        return functions;
+    }
+
+    public RangedInt getRolls() {
+        return rolls;
+    }
+
+    public RangedInt getBonusRolls() {
+        return bonusRolls;
+    }
+
+    public List<PoolEntry> getEntries() {
+        return entries;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/SourceEntity.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/SourceEntity.java
@@ -1,0 +1,10 @@
+package net.glowstone.datapack.loader.model.external.loottable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum SourceEntity {
+    @JsonProperty("block_entity") BLOCK_ENTITY,
+    @JsonProperty("this") THIS,
+    @JsonProperty("killer") KILLER,
+    @JsonProperty("killer_player") KILLER_PLAYER,
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/AlternativeCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/AlternativeCondition.java
@@ -1,0 +1,22 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class AlternativeCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:alternative";
+
+    private final List<Condition> terms;
+
+    @JsonCreator
+    public AlternativeCondition(
+        @JsonProperty("terms") List<Condition> terms) {
+        this.terms = terms;
+    }
+
+    public List<Condition> getTerms() {
+        return terms;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/BlockStatePropertyCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/BlockStatePropertyCondition.java
@@ -1,0 +1,30 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class BlockStatePropertyCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:block_state_property";
+
+    private final String block;
+    private final Optional<Map<String, String>> properties;
+
+    @JsonCreator
+    public BlockStatePropertyCondition(
+        @JsonProperty("block") String block,
+        @JsonProperty("properties") Optional<Map<String, String>> properties) {
+        this.block = block;
+        this.properties = properties;
+    }
+
+    public String getBlock() {
+        return block;
+    }
+
+    public Optional<Map<String, String>> getProperties() {
+        return properties;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/Condition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/Condition.java
@@ -1,0 +1,31 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "condition"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = AlternativeCondition.class, name = AlternativeCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = BlockStatePropertyCondition.class, name = BlockStatePropertyCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = DamageSourcePropertiesCondition.class, name = DamageSourcePropertiesCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = EntityPropertiesCondition.class, name = EntityPropertiesCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = EntityScoresCondition.class, name = EntityScoresCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = InvertedCondition.class, name = InvertedCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = KilledByPlayerCondition.class, name = KilledByPlayerCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = LocationCheckCondition.class, name = LocationCheckCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = MatchToolCondition.class, name = MatchToolCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = RandomChanceCondition.class, name = RandomChanceCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = RandomChanceWithLootingCondition.class, name = RandomChanceWithLootingCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = ReferenceCondition.class, name = ReferenceCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = SurvivesExplosionCondition.class, name = SurvivesExplosionCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = TableBonusCondition.class, name = TableBonusCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = TimeCheckCondition.class, name = TimeCheckCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = ToolEnchantmentCondition.class, name = ToolEnchantmentCondition.TYPE_ID),
+    @JsonSubTypes.Type(value = WeatherCheckCondition.class, name = WeatherCheckCondition.TYPE_ID),
+})
+public interface Condition {
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/DamageSourcePropertiesCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/DamageSourcePropertiesCondition.java
@@ -1,0 +1,17 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.DamageType;
+
+public class DamageSourcePropertiesCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:damage_source_properties";
+
+    private final DamageType predicate;
+
+    @JsonCreator
+    public DamageSourcePropertiesCondition(
+        @JsonProperty("predicate") DamageType predicate) {
+        this.predicate = predicate;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/EntityPropertiesCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/EntityPropertiesCondition.java
@@ -1,0 +1,29 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+import net.glowstone.datapack.loader.model.external.loottable.SourceEntity;
+
+public class EntityPropertiesCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:entity_properties";
+
+    private final SourceEntity entity;
+    private final Entity predicate;
+
+    @JsonCreator
+    public EntityPropertiesCondition(
+        @JsonProperty("entity") SourceEntity entity,
+        @JsonProperty("predicate") Entity predicate) {
+        this.entity = entity;
+        this.predicate = predicate;
+    }
+
+    public SourceEntity getEntity() {
+        return entity;
+    }
+
+    public Entity getPredicate() {
+        return predicate;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/EntityScoresCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/EntityScoresCondition.java
@@ -1,0 +1,31 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+import net.glowstone.datapack.loader.model.external.loottable.SourceEntity;
+
+import java.util.Map;
+
+public class EntityScoresCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:entity_scores";
+
+    private final SourceEntity entity;
+    private final Map<String, RangedInt> scores;
+
+    @JsonCreator
+    public EntityScoresCondition(
+        @JsonProperty("entity") SourceEntity entity,
+        @JsonProperty("scores") Map<String, RangedInt> scores) {
+        this.entity = entity;
+        this.scores = scores;
+    }
+
+    public SourceEntity getEntity() {
+        return entity;
+    }
+
+    public Map<String, RangedInt> getScores() {
+        return scores;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/InvertedCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/InvertedCondition.java
@@ -1,0 +1,22 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class InvertedCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:inverted";
+
+    private final Condition term;
+
+    @JsonCreator
+    public InvertedCondition(
+        @JsonProperty("term") Condition term) {
+        this.term = term;
+    }
+
+    public Condition getTerm() {
+        return term;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/KilledByPlayerCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/KilledByPlayerCondition.java
@@ -1,0 +1,20 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class KilledByPlayerCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:killed_by_player";
+
+    private final boolean inverse;
+
+    @JsonCreator
+    public KilledByPlayerCondition(
+        @JsonProperty("inverse") boolean inverse) {
+        this.inverse = inverse;
+    }
+
+    public boolean isInverse() {
+        return inverse;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/LocationCheckCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/LocationCheckCondition.java
@@ -1,0 +1,44 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Location;
+
+import java.util.OptionalInt;
+
+public class LocationCheckCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:location_check";
+
+    private final OptionalInt offsetX;
+    private final OptionalInt offsetY;
+    private final OptionalInt offsetZ;
+    private final Location predicate;
+
+    @JsonCreator
+    public LocationCheckCondition(
+        @JsonProperty("offsetX") OptionalInt offsetX,
+        @JsonProperty("offsetY") OptionalInt offsetY,
+        @JsonProperty("offsetZ") OptionalInt offsetZ,
+        @JsonProperty("predicate") Location predicate) {
+        this.offsetX = offsetX;
+        this.offsetY = offsetY;
+        this.offsetZ = offsetZ;
+        this.predicate = predicate;
+    }
+
+    public OptionalInt getOffsetX() {
+        return offsetX;
+    }
+
+    public OptionalInt getOffsetY() {
+        return offsetY;
+    }
+
+    public OptionalInt getOffsetZ() {
+        return offsetZ;
+    }
+
+    public Location getPredicate() {
+        return predicate;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/MatchToolCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/MatchToolCondition.java
@@ -1,0 +1,21 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Item;
+
+public class MatchToolCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:match_tool";
+
+    private final Item predicate;
+
+    @JsonCreator
+    public MatchToolCondition(
+        @JsonProperty("item") Item predicate) {
+        this.predicate = predicate;
+    }
+
+    public Item getPredicate() {
+        return predicate;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/RandomChanceCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/RandomChanceCondition.java
@@ -1,0 +1,20 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RandomChanceCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:random_chance";
+
+    private final float chance;
+
+    @JsonCreator
+    public RandomChanceCondition(
+        @JsonProperty("chance") float chance) {
+        this.chance = chance;
+    }
+
+    public float getChance() {
+        return chance;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/RandomChanceWithLootingCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/RandomChanceWithLootingCondition.java
@@ -1,0 +1,27 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RandomChanceWithLootingCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:random_chance_with_looting";
+
+    private final float chance;
+    private final float lootingMultiplier;
+
+    @JsonCreator
+    public RandomChanceWithLootingCondition(
+        @JsonProperty("chance") float chance,
+        @JsonProperty("looting_multiplier") float lootingMultiplier) {
+        this.chance = chance;
+        this.lootingMultiplier = lootingMultiplier;
+    }
+
+    public float getChance() {
+        return chance;
+    }
+
+    public float getLootingMultiplier() {
+        return lootingMultiplier;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/ReferenceCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/ReferenceCondition.java
@@ -1,0 +1,20 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ReferenceCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:reference";
+
+    private final String name;
+
+    @JsonCreator
+    public ReferenceCondition(
+        @JsonProperty("name") String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/SurvivesExplosionCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/SurvivesExplosionCondition.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+public class SurvivesExplosionCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:survives_explosion";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/TableBonusCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/TableBonusCondition.java
@@ -1,0 +1,29 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class TableBonusCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:table_bonus";
+
+    private final String enchantment;
+    private final List<Float> chances;
+
+    @JsonCreator
+    public TableBonusCondition(
+        @JsonProperty("enchantment") String enchantment,
+        @JsonProperty("chances") List<Float> chances) {
+        this.enchantment = enchantment;
+        this.chances = chances;
+    }
+
+    public String getEnchantment() {
+        return enchantment;
+    }
+
+    public List<Float> getChances() {
+        return chances;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/TimeCheckCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/TimeCheckCondition.java
@@ -1,0 +1,30 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+
+import java.util.OptionalInt;
+
+public class TimeCheckCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:time_check";
+
+    private final RangedInt value;
+    private final OptionalInt period;
+
+    @JsonCreator
+    public TimeCheckCondition(
+        @JsonProperty("value") RangedInt value,
+        @JsonProperty("period") OptionalInt period) {
+        this.value = value;
+        this.period = period;
+    }
+
+    public RangedInt getValue() {
+        return value;
+    }
+
+    public OptionalInt getPeriod() {
+        return period;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/ToolEnchantmentCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/ToolEnchantmentCondition.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Enchantment;
+
+import java.util.List;
+
+public class ToolEnchantmentCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:tool_enchantment";
+
+    private final List<Enchantment> enchantments;
+
+    @JsonCreator
+    public ToolEnchantmentCondition(
+        @JsonProperty("enchantments") List<Enchantment> enchantments) {
+        this.enchantments = enchantments;
+    }
+
+    public List<Enchantment> getEnchantments() {
+        return enchantments;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/WeatherCheckCondition.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/condition/WeatherCheckCondition.java
@@ -1,0 +1,27 @@
+package net.glowstone.datapack.loader.model.external.loottable.condition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class WeatherCheckCondition implements Condition {
+    public static final String TYPE_ID = "minecraft:weather_check";
+
+    private final boolean raining;
+    private final boolean thundering;
+
+    @JsonCreator
+    public WeatherCheckCondition(
+        @JsonProperty("raining") boolean raining,
+        @JsonProperty("thundering") boolean thundering) {
+        this.raining = raining;
+        this.thundering = thundering;
+    }
+
+    public boolean isRaining() {
+        return raining;
+    }
+
+    public boolean isThundering() {
+        return thundering;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/AlternativesPoolEntry.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/AlternativesPoolEntry.java
@@ -1,0 +1,27 @@
+package net.glowstone.datapack.loader.model.external.loottable.entry;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class AlternativesPoolEntry extends PoolEntry {
+    public static final String TYPE_ID = "minecraft:alternatives";
+
+    private final List<PoolEntry> children;
+
+    @JsonCreator
+    public AlternativesPoolEntry(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("weight") int weight,
+        @JsonProperty("quality") int quality,
+        @JsonProperty("children") List<PoolEntry> children) {
+        super(conditions, weight, quality);
+        this.children = children;
+    }
+
+    public List<PoolEntry> getChildren() {
+        return children;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/DynamicPoolEntry.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/DynamicPoolEntry.java
@@ -1,0 +1,32 @@
+package net.glowstone.datapack.loader.model.external.loottable.entry;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class DynamicPoolEntry extends PoolEntry {
+    public enum Name {
+        @JsonProperty("minecraft:contents") CONTENTS,
+        @JsonProperty("minecraft:self") SELF,
+    }
+
+    public static final String TYPE_ID = "minecraft:dynamic";
+
+    private final Name name;
+
+    @JsonCreator
+    public DynamicPoolEntry(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("weight") int weight,
+        @JsonProperty("quality") int quality,
+        @JsonProperty("name") Name name) {
+        super(conditions, weight, quality);
+        this.name = name;
+    }
+
+    public Name getName() {
+        return name;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/EmptyPoolEntry.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/EmptyPoolEntry.java
@@ -1,0 +1,19 @@
+package net.glowstone.datapack.loader.model.external.loottable.entry;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class EmptyPoolEntry extends PoolEntry {
+    public static final String TYPE_ID = "minecraft:empty";
+
+    @JsonCreator
+    public EmptyPoolEntry(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("weight") int weight,
+        @JsonProperty("quality") int quality) {
+        super(conditions, weight, quality);
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/GroupPoolEntry.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/GroupPoolEntry.java
@@ -1,0 +1,27 @@
+package net.glowstone.datapack.loader.model.external.loottable.entry;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class GroupPoolEntry extends PoolEntry {
+    public static final String TYPE_ID = "minecraft:group";
+
+    private final List<PoolEntry> children;
+
+    @JsonCreator
+    public GroupPoolEntry(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("weight") int weight,
+        @JsonProperty("quality") int quality,
+        @JsonProperty("children") List<PoolEntry> children) {
+        super(conditions, weight, quality);
+        this.children = children;
+    }
+
+    public List<PoolEntry> getChildren() {
+        return children;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/ItemPoolEntry.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/ItemPoolEntry.java
@@ -1,0 +1,35 @@
+package net.glowstone.datapack.loader.model.external.loottable.entry;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.function.Function;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class ItemPoolEntry extends PoolEntry {
+    public static final String TYPE_ID = "minecraft:item";
+    
+    private final String name;
+    private final List<Function> functions;
+
+    @JsonCreator
+    public ItemPoolEntry(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("weight") int weight,
+        @JsonProperty("quality") int quality,
+        @JsonProperty("name") String name,
+        @JsonProperty("functions") List<Function> functions) {
+        super(conditions, weight, quality);
+        this.name = name;
+        this.functions = functions;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<Function> getFunctions() {
+        return functions;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/LootTablePoolEntry.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/LootTablePoolEntry.java
@@ -1,0 +1,27 @@
+package net.glowstone.datapack.loader.model.external.loottable.entry;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class LootTablePoolEntry extends PoolEntry {
+    public static final String TYPE_ID = "minecraft:loot_table";
+
+    private final String name;
+
+    @JsonCreator
+    public LootTablePoolEntry(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("weight") int weight,
+        @JsonProperty("quality") int quality,
+        @JsonProperty("name") String name) {
+        super(conditions, weight, quality);
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/PoolEntry.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/PoolEntry.java
@@ -1,0 +1,46 @@
+package net.glowstone.datapack.loader.model.external.loottable.entry;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = AlternativesPoolEntry.class, name = AlternativesPoolEntry.TYPE_ID),
+    @JsonSubTypes.Type(value = DynamicPoolEntry.class, name = DynamicPoolEntry.TYPE_ID),
+    @JsonSubTypes.Type(value = EmptyPoolEntry.class, name = EmptyPoolEntry.TYPE_ID),
+    @JsonSubTypes.Type(value = GroupPoolEntry.class, name = GroupPoolEntry.TYPE_ID),
+    @JsonSubTypes.Type(value = ItemPoolEntry.class, name = ItemPoolEntry.TYPE_ID),
+    @JsonSubTypes.Type(value = LootTablePoolEntry.class, name = LootTablePoolEntry.TYPE_ID),
+    @JsonSubTypes.Type(value = SequencePoolEntry.class, name = SequencePoolEntry.TYPE_ID),
+    @JsonSubTypes.Type(value = TagPoolEntry.class, name = TagPoolEntry.TYPE_ID),
+})
+public abstract class PoolEntry {
+    private final List<Condition> conditions;
+    private final int weight;
+    private final int quality;
+
+    protected PoolEntry(List<Condition> conditions, int weight, int quality) {
+        this.conditions = conditions;
+        this.weight = weight;
+        this.quality = quality;
+    }
+
+    public List<Condition> getConditions() {
+        return conditions;
+    }
+
+    public int getWeight() {
+        return weight;
+    }
+
+    public int getQuality() {
+        return quality;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/SequencePoolEntry.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/SequencePoolEntry.java
@@ -1,0 +1,27 @@
+package net.glowstone.datapack.loader.model.external.loottable.entry;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class SequencePoolEntry extends PoolEntry {
+    public static final String TYPE_ID = "minecraft:sequence";
+
+    private final List<PoolEntry> children;
+
+    @JsonCreator
+    public SequencePoolEntry(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("weight") int weight,
+        @JsonProperty("quality") int quality,
+        @JsonProperty("children") List<PoolEntry> children) {
+        super(conditions, weight, quality);
+        this.children = children;
+    }
+
+    public List<PoolEntry> getChildren() {
+        return children;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/TagPoolEntry.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/entry/TagPoolEntry.java
@@ -1,0 +1,34 @@
+package net.glowstone.datapack.loader.model.external.loottable.entry;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class TagPoolEntry extends PoolEntry {
+    public static final String TYPE_ID = "minecraft:tag";
+
+    private final String name;
+    private final boolean expand;
+
+    @JsonCreator
+    public TagPoolEntry(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("weight") int weight,
+        @JsonProperty("quality") int quality,
+        @JsonProperty("name") String name,
+        @JsonProperty("expand") boolean expand) {
+        super(conditions, weight, quality);
+        this.name = name;
+        this.expand = expand;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isExpand() {
+        return expand;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/ApplyBonusFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/ApplyBonusFunction.java
@@ -1,0 +1,67 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class ApplyBonusFunction extends Function {
+    public static class Parameters {
+        private final int extra;
+        private final float probability;
+        private final float bonusMultiplier;
+
+        @JsonCreator
+        public Parameters(
+            @JsonProperty("extra") int extra,
+            @JsonProperty("probability") float probability,
+            @JsonProperty("bonusMultiplier") float bonusMultiplier) {
+            this.extra = extra;
+            this.probability = probability;
+            this.bonusMultiplier = bonusMultiplier;
+        }
+
+        public int getExtra() {
+            return extra;
+        }
+
+        public float getProbability() {
+            return probability;
+        }
+
+        public float getBonusMultiplier() {
+            return bonusMultiplier;
+        }
+    }
+
+    public static final String TYPE_ID = "minecraft:apply_bonus";
+
+    private final String enchantment;
+    private final String formula;
+    private final Parameters parameters;
+
+    @JsonCreator
+    public ApplyBonusFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("enchantment") String enchantment,
+        @JsonProperty("formula") String formula,
+        @JsonProperty("parameters") Parameters parameters) {
+        super(conditions);
+        this.enchantment = enchantment;
+        this.formula = formula;
+        this.parameters = parameters;
+    }
+
+    public String getEnchantment() {
+        return enchantment;
+    }
+
+    public String getFormula() {
+        return formula;
+    }
+
+    public Parameters getParameters() {
+        return parameters;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/CopyNameFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/CopyNameFunction.java
@@ -1,0 +1,29 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class CopyNameFunction extends Function {
+    public enum Source {
+        @JsonProperty("block_entity") BLOCK_ENTITY,
+    }
+
+    public static final String TYPE_ID = "minecraft:copy_name";
+
+    private final Source source;
+
+    @JsonCreator
+    public CopyNameFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("source") Source source) {
+        super(conditions);
+        this.source = source;
+    }
+
+    public Source getSource() {
+        return source;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/CopyNbtFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/CopyNbtFunction.java
@@ -1,0 +1,67 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+import net.glowstone.datapack.loader.model.external.loottable.SourceEntity;
+
+import java.util.List;
+
+public class CopyNbtFunction extends Function {
+    public enum Operation {
+        @JsonProperty("append") APPEND,
+        @JsonProperty("merge") MERGE,
+        @JsonProperty("replace") REPLACE,
+    }
+
+    public static class OperationTargets {
+        private final String source;
+        private final String target;
+        private final Operation op;
+
+        @JsonCreator
+        public OperationTargets(
+            @JsonProperty("source") String source,
+            @JsonProperty("target") String target,
+            @JsonProperty("op") Operation op) {
+            this.source = source;
+            this.target = target;
+            this.op = op;
+        }
+
+        public String getSource() {
+            return source;
+        }
+
+        public String getTarget() {
+            return target;
+        }
+
+        public Operation getOp() {
+            return op;
+        }
+    }
+
+    public static final String TYPE_ID = "minecraft:copy_nbt";
+
+    private final SourceEntity source;
+    private final List<OperationTargets> ops;
+
+    @JsonCreator
+    public CopyNbtFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("source") SourceEntity source,
+        @JsonProperty("ops") List<OperationTargets> ops) {
+        super(conditions);
+        this.source = source;
+        this.ops = ops;
+    }
+
+    public SourceEntity getSource() {
+        return source;
+    }
+
+    public List<OperationTargets> getOps() {
+        return ops;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/CopyStateFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/CopyStateFunction.java
@@ -1,0 +1,32 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class CopyStateFunction extends Function {
+    public static final String TYPE_ID = "minecraft:copy_state";
+
+    private final String block;
+    private final List<String> properties;
+
+    @JsonCreator
+    public CopyStateFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("block") String block,
+        @JsonProperty("properties") List<String> properties) {
+        super(conditions);
+        this.block = block;
+        this.properties = properties;
+    }
+
+    public String getBlock() {
+        return block;
+    }
+
+    public List<String> getProperties() {
+        return properties;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/EnchantRandomlyFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/EnchantRandomlyFunction.java
@@ -1,0 +1,26 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+import java.util.Optional;
+
+public class EnchantRandomlyFunction extends Function {
+    public static final String TYPE_ID = "minecraft:enchant_randomly";
+
+    private final Optional<List<String>> enchantments;
+
+    @JsonCreator
+    public EnchantRandomlyFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("enchantments") Optional<List<String>> enchantments) {
+        super(conditions);
+        this.enchantments = enchantments;
+    }
+
+    public Optional<List<String>> getEnchantments() {
+        return enchantments;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/EnchantWithLevelsFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/EnchantWithLevelsFunction.java
@@ -1,0 +1,33 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+
+import java.util.List;
+
+public class EnchantWithLevelsFunction extends Function {
+    public static final String TYPE_ID = "minecraft:enchant_with_levels";
+
+    private final boolean treasure;
+    private final RangedInt levels;
+
+    @JsonCreator
+    public EnchantWithLevelsFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("treasure") boolean treasure,
+        @JsonProperty("levels") RangedInt levels) {
+        super(conditions);
+        this.treasure = treasure;
+        this.levels = levels;
+    }
+
+    public boolean isTreasure() {
+        return treasure;
+    }
+
+    public RangedInt getLevels() {
+        return levels;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/ExplorationMapFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/ExplorationMapFunction.java
@@ -1,0 +1,55 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class ExplorationMapFunction extends Function {
+    public static final String TYPE_ID = "minecraft:exploration_map";
+
+    private final String destination;
+    private final String decoration;
+    private final int zoom;
+    private final int searchRadius;
+    private final boolean skipExistingChunks;
+
+    @JsonCreator
+    public ExplorationMapFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("destination") String destination,
+        @JsonProperty("decoration") String decoration,
+        @JsonProperty("zoom") OptionalInt zoom,
+        @JsonProperty("search_radius") OptionalInt searchRadius,
+        @JsonProperty("skip_existing_chunks") Optional<Boolean> skipExistingChunks) {
+        super(conditions);
+        this.destination = destination;
+        this.decoration = decoration;
+        this.zoom = zoom.orElse(2);
+        this.searchRadius = searchRadius.orElse(50);
+        this.skipExistingChunks = skipExistingChunks.orElse(true);
+    }
+
+    public String getDestination() {
+        return destination;
+    }
+
+    public String getDecoration() {
+        return decoration;
+    }
+
+    public int getZoom() {
+        return zoom;
+    }
+
+    public int getSearchRadius() {
+        return searchRadius;
+    }
+
+    public boolean isSkipExistingChunks() {
+        return skipExistingChunks;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/ExplosionDecayFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/ExplosionDecayFunction.java
@@ -1,0 +1,17 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class ExplosionDecayFunction extends Function {
+    public static final String TYPE_ID = "minecraft:explosion_decay";
+
+    @JsonCreator
+    public ExplosionDecayFunction(
+        @JsonProperty("conditions") List<Condition> conditions) {
+        super(conditions);
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/FillPlayerHeadFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/FillPlayerHeadFunction.java
@@ -1,0 +1,26 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+import net.glowstone.datapack.loader.model.external.loottable.SourceEntity;
+
+import java.util.List;
+
+public class FillPlayerHeadFunction extends Function {
+    public static final String TYPE_ID = "minecraft:fill_player_head";
+
+    private final SourceEntity entity;
+
+    @JsonCreator
+    public FillPlayerHeadFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("entity") SourceEntity entity) {
+        super(conditions);
+        this.entity = entity;
+    }
+
+    public SourceEntity getEntity() {
+        return entity;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/Function.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/Function.java
@@ -1,0 +1,47 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "function"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ApplyBonusFunction.class, name = ApplyBonusFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = CopyNameFunction.class, name = CopyNameFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = CopyNbtFunction.class, name = CopyNbtFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = CopyStateFunction.class, name = CopyStateFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = EnchantRandomlyFunction.class, name = EnchantRandomlyFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = EnchantWithLevelsFunction.class, name = EnchantWithLevelsFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = ExplorationMapFunction.class, name = ExplorationMapFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = ExplosionDecayFunction.class, name = ExplosionDecayFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = FurnaceSmeltFunction.class, name = FurnaceSmeltFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = FillPlayerHeadFunction.class, name = FillPlayerHeadFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = LimitCountFunction.class, name = LimitCountFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = LootingEnchantFunction.class, name = LootingEnchantFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = SetAttributesFunction.class, name = SetAttributesFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = SetContentsFunction.class, name = SetContentsFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = SetCountFunction.class, name = SetCountFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = SetDamageFunction.class, name = SetDamageFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = SetLoreFunction.class, name = SetLoreFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = SetNameFunction.class, name = SetNameFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = SetNbtFunction.class, name = SetNbtFunction.TYPE_ID),
+    @JsonSubTypes.Type(value = SetStewEffectFunction.class, name = SetStewEffectFunction.TYPE_ID),
+})
+public abstract class Function {
+    private final List<Condition> conditions;
+
+    public Function(
+        List<Condition> conditions) {
+        this.conditions = conditions;
+    }
+
+    public List<Condition> getCondition() {
+        return conditions;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/FurnaceSmeltFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/FurnaceSmeltFunction.java
@@ -1,0 +1,17 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class FurnaceSmeltFunction extends Function {
+    public static final String TYPE_ID = "minecraft:furnace_smelt";
+
+    @JsonCreator
+    public FurnaceSmeltFunction(
+        @JsonProperty("conditions") List<Condition> conditions) {
+        super(conditions);
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/LimitCountFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/LimitCountFunction.java
@@ -1,0 +1,26 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+
+import java.util.List;
+
+public class LimitCountFunction extends Function {
+    public static final String TYPE_ID = "minecraft:limit_count";
+
+    private final RangedInt limit;
+
+    @JsonCreator
+    public LimitCountFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("limit") RangedInt limit) {
+        super(conditions);
+        this.limit = limit;
+    }
+
+    public RangedInt getLimit() {
+        return limit;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/LootingEnchantFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/LootingEnchantFunction.java
@@ -1,0 +1,33 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+
+import java.util.List;
+
+public class LootingEnchantFunction extends Function {
+    public static final String TYPE_ID = "minecraft:looting_enchant";
+
+    private final RangedInt count;
+    private final int limit;
+
+    @JsonCreator
+    public LootingEnchantFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("count") RangedInt count,
+        @JsonProperty("limit") int limit) {
+        super(conditions);
+        this.count = count;
+        this.limit = limit;
+    }
+
+    public RangedInt getCount() {
+        return count;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetAttributesFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetAttributesFunction.java
@@ -1,0 +1,90 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedDouble;
+
+import java.util.List;
+
+public class SetAttributesFunction extends Function {
+    public enum Operation {
+        ADDITION,
+        MULTIPLY_BASE,
+        MULTIPLY_TOTAL,
+    }
+
+    public enum Slot {
+        @JsonProperty("mainhand") MAINHAND,
+        @JsonProperty("offhand") OFFHAND,
+        @JsonProperty("feet") FEET,
+        @JsonProperty("legs") LEGS,
+        @JsonProperty("chest") CHEST,
+        @JsonProperty("head") HEAD,
+    }
+
+    public static class Modifier {
+        private final String name;
+        private final String attribute;
+        private final Operation operation;
+        private final RangedDouble amount;
+        private final String id;
+        private final List<Slot> slot;
+
+        @JsonCreator
+        public Modifier(
+            @JsonProperty("name") String name,
+            @JsonProperty("attribute") String attribute,
+            @JsonProperty("operation") Operation operation,
+            @JsonProperty("amount") RangedDouble amount,
+            @JsonProperty("id") String id,
+            @JsonProperty("slot") List<Slot> slot) {
+            this.name = name;
+            this.attribute = attribute;
+            this.operation = operation;
+            this.amount = amount;
+            this.id = id;
+            this.slot = slot;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getAttribute() {
+            return attribute;
+        }
+
+        public Operation getOperation() {
+            return operation;
+        }
+
+        public RangedDouble getAmount() {
+            return amount;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public List<Slot> getSlot() {
+            return slot;
+        }
+    }
+
+    public static final String TYPE_ID = "minecraft:set_attributes";
+
+    private final List<Modifier> modifiers;
+
+    @JsonCreator
+    public SetAttributesFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("modifiers") List<Modifier> modifiers) {
+        super(conditions);
+        this.modifiers = modifiers;
+    }
+
+    public List<Modifier> getModifiers() {
+        return modifiers;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetContentsFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetContentsFunction.java
@@ -1,0 +1,26 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+import net.glowstone.datapack.loader.model.external.loottable.entry.PoolEntry;
+
+import java.util.List;
+
+public class SetContentsFunction extends Function {
+    public static final String TYPE_ID = "minecraft:set_contents";
+
+    private final List<PoolEntry> entries;
+
+    @JsonCreator
+    public SetContentsFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("entries") List<PoolEntry> entries) {
+        super(conditions);
+        this.entries = entries;
+    }
+
+    public List<PoolEntry> getEntries() {
+        return entries;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetCountFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetCountFunction.java
@@ -1,0 +1,130 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+
+import java.io.IOException;
+import java.util.List;
+
+public class SetCountFunction extends Function {
+    public static class CountDeserializer extends StdDeserializer<Count> {
+        public CountDeserializer() {
+            super(Count.class);
+        }
+
+        @Override
+        public Count deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            switch (p.getCurrentToken()) {
+                case VALUE_NUMBER_INT:
+                    return new ConstantCount(p.getIntValue());
+
+                case START_OBJECT:
+                    return p.getCodec().readValue(p, DistributionCount.class);
+
+                default:
+                    throw new JsonMappingException(p, "Cannot create SetCountFunction.Count");
+            }
+        }
+    }
+
+    @JsonDeserialize(using = CountDeserializer.class)
+    public interface Count {}
+
+    public static class ConstantCount implements Count {
+        private final int value;
+
+        public ConstantCount(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    @JsonDeserialize(using = JsonDeserializer.None.class)
+    @JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type"
+    )
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = UniformDistributionCount.class, name = UniformDistributionCount.TYPE_ID),
+        @JsonSubTypes.Type(value = BinomialDistributionCount.class, name = BinomialDistributionCount.TYPE_ID),
+    })
+    public interface DistributionCount extends Count {}
+
+    public static class UniformDistributionCount implements DistributionCount {
+        public static final String TYPE_ID = "minecraft:uniform";
+
+        private final int min;
+        private final int max;
+
+        @JsonCreator
+        public UniformDistributionCount(
+            @JsonProperty("min") int min,
+            @JsonProperty("max") int max) {
+            this.min = min;
+            this.max = max;
+        }
+
+        public int getMin() {
+            return min;
+        }
+
+        public int getMax() {
+            return max;
+        }
+    }
+
+    public static class BinomialDistributionCount implements DistributionCount {
+        public static final String TYPE_ID = "minecraft:binomial";
+
+        private final int n;
+        private final float p;
+
+        @JsonCreator
+        public BinomialDistributionCount(
+            @JsonProperty("n") int n,
+            @JsonProperty("p") float p) {
+            this.n = n;
+            this.p = p;
+        }
+
+        public int getN() {
+            return n;
+        }
+
+        public float getP() {
+            return p;
+        }
+    }
+
+    public static final String TYPE_ID = "minecraft:set_count";
+
+    private final Count count;
+
+    @JsonCreator
+    public SetCountFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("count") Count count) {
+        super(conditions);
+        this.count = count;
+    }
+
+    public Count getCount() {
+        return count;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetDamageFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetDamageFunction.java
@@ -1,0 +1,26 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedDouble;
+
+import java.util.List;
+
+public class SetDamageFunction extends Function {
+    public static final String TYPE_ID = "minecraft:set_damage";
+
+    private final RangedDouble damage;
+
+    @JsonCreator
+    public SetDamageFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("damage") RangedDouble damage) {
+        super(conditions);
+        this.damage = damage;
+    }
+
+    public RangedDouble getDamage() {
+        return damage;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetLoreFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetLoreFunction.java
@@ -1,0 +1,41 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+import net.glowstone.datapack.loader.model.external.loottable.SourceEntity;
+import net.glowstone.datapack.loader.model.external.text.RawJsonText;
+
+import java.util.List;
+
+public class SetLoreFunction extends Function {
+    public static final String TYPE_ID = "minecraft:set_lore";
+
+    private final List<RawJsonText> lore;
+    private final SourceEntity entity;
+    private final boolean replace;
+
+    @JsonCreator
+    public SetLoreFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("lore") List<RawJsonText> lore,
+        @JsonProperty("entity") SourceEntity entity,
+        boolean replace) {
+        super(conditions);
+        this.lore = lore;
+        this.entity = entity;
+        this.replace = replace;
+    }
+
+    public List<RawJsonText> getLore() {
+        return lore;
+    }
+
+    public SourceEntity getEntity() {
+        return entity;
+    }
+
+    public boolean isReplace() {
+        return replace;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetNameFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetNameFunction.java
@@ -1,0 +1,29 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.SourceEntity;
+import net.glowstone.datapack.loader.model.external.text.RawJsonText;
+
+public class SetNameFunction {
+    public static final String TYPE_ID = "minecraft:set_name";
+
+    private final RawJsonText name;
+    private final SourceEntity entity;
+
+    @JsonCreator
+    public SetNameFunction(
+        @JsonProperty("name") RawJsonText name,
+        @JsonProperty("entity") SourceEntity entity) {
+        this.name = name;
+        this.entity = entity;
+    }
+
+    public RawJsonText getName() {
+        return name;
+    }
+
+    public SourceEntity getEntity() {
+        return entity;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetNbtFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetNbtFunction.java
@@ -1,0 +1,25 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class SetNbtFunction extends Function {
+    public static final String TYPE_ID = "minecraft:set_nbt";
+
+    private final String tag;
+
+    @JsonCreator
+    public SetNbtFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("tag") String tag) {
+        super(conditions);
+        this.tag = tag;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetStewEffectFunction.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/loottable/function/SetStewEffectFunction.java
@@ -1,0 +1,47 @@
+package net.glowstone.datapack.loader.model.external.loottable.function;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+import net.glowstone.datapack.loader.model.external.loottable.condition.Condition;
+
+import java.util.List;
+
+public class SetStewEffectFunction extends Function {
+    public static class Effect {
+        private final String type;
+        private final RangedInt duration;
+
+        @JsonCreator
+        public Effect(
+            @JsonProperty("type") String type,
+            @JsonProperty("duration") RangedInt duration) {
+            this.type = type;
+            this.duration = duration;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public RangedInt getDuration() {
+            return duration;
+        }
+    }
+
+    public static final String TYPE_ID = "minecraft:set_stew_effect";
+
+    private final List<Effect> effects;
+
+    @JsonCreator
+    public SetStewEffectFunction(
+        @JsonProperty("conditions") List<Condition> conditions,
+        @JsonProperty("effects") List<Effect> effects) {
+        super(conditions);
+        this.effects = effects;
+    }
+
+    public List<Effect> getEffects() {
+        return effects;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/mcmeta/McMeta.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/mcmeta/McMeta.java
@@ -1,0 +1,17 @@
+package net.glowstone.datapack.loader.model.external.mcmeta;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class McMeta {
+    private final McMetaPack pack;
+
+    @JsonCreator
+    public McMeta(@JsonProperty("pack") McMetaPack pack) {
+        this.pack = pack;
+    }
+
+    public McMetaPack getPack() {
+        return pack;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/mcmeta/McMetaPack.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/mcmeta/McMetaPack.java
@@ -1,0 +1,25 @@
+package net.glowstone.datapack.loader.model.external.mcmeta;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class McMetaPack {
+    private final int packFormat;
+    private final String description;
+
+    @JsonCreator
+    public McMetaPack(
+        @JsonProperty("pack_format") int packFormat,
+        @JsonProperty("description") String description) {
+        this.packFormat = packFormat;
+        this.description = description;
+    }
+
+    public int getPackFormat() {
+        return packFormat;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/AlternativePredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/AlternativePredicate.java
@@ -1,0 +1,22 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class AlternativePredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:alternative";
+
+    private final List<Predicate> terms;
+
+    @JsonCreator
+    public AlternativePredicate(
+        @JsonProperty("terms") List<Predicate> terms) {
+        this.terms = terms;
+    }
+
+    public List<Predicate> getTerms() {
+        return terms;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/BlockStatePropertyPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/BlockStatePropertyPredicate.java
@@ -1,0 +1,30 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class BlockStatePropertyPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:block_state_property";
+
+    private final String block;
+    private final Optional<Map<String, String>> properties;
+
+    @JsonCreator
+    public BlockStatePropertyPredicate(
+        @JsonProperty("block") String block,
+        @JsonProperty("properties") Optional<Map<String, String>> properties) {
+        this.block = block;
+        this.properties = properties;
+    }
+
+    public String getBlock() {
+        return block;
+    }
+
+    public Optional<Map<String, String>> getProperties() {
+        return properties;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/DamageSourcePropertiesPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/DamageSourcePropertiesPredicate.java
@@ -1,0 +1,21 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.DamageType;
+
+public class DamageSourcePropertiesPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:damage_source_properties";
+    
+    private final DamageType predicate;
+
+    @JsonCreator
+    public DamageSourcePropertiesPredicate(
+        @JsonProperty("predicate") DamageType predicate) {
+        this.predicate = predicate;
+    }
+
+    public DamageType getPredicate() {
+        return predicate;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/EntityPropertiesPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/EntityPropertiesPredicate.java
@@ -1,0 +1,28 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Entity;
+
+public class EntityPropertiesPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:entity_properties";
+
+    private final String entity;
+    private final Entity predicate;
+
+    @JsonCreator
+    public EntityPropertiesPredicate(
+        @JsonProperty("entity") String entity,
+        @JsonProperty("predicate") Entity predicate) {
+        this.entity = entity;
+        this.predicate = predicate;
+    }
+
+    public String getEntity() {
+        return entity;
+    }
+
+    public Entity getPredicate() {
+        return predicate;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/EntityScoresPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/EntityScoresPredicate.java
@@ -1,0 +1,30 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+
+import java.util.Map;
+
+public class EntityScoresPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:entity_scores";
+
+    private final String entity;
+    private final Map<String, RangedInt> scores;
+
+    @JsonCreator
+    public EntityScoresPredicate(
+        @JsonProperty("entity") String entity,
+        @JsonProperty("scores") Map<String, RangedInt> scores) {
+        this.entity = entity;
+        this.scores = scores;
+    }
+
+    public String getEntity() {
+        return entity;
+    }
+
+    public Map<String, RangedInt> getScores() {
+        return scores;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/InvertedPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/InvertedPredicate.java
@@ -1,0 +1,20 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class InvertedPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:inverted";
+
+    private final Predicate inverted;
+
+    @JsonCreator
+    public InvertedPredicate(
+        @JsonProperty("inverted") Predicate inverted) {
+        this.inverted = inverted;
+    }
+
+    public Predicate getInverted() {
+        return inverted;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/KilledByPlayerPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/KilledByPlayerPredicate.java
@@ -1,0 +1,20 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class KilledByPlayerPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:killed_by_player";
+
+    private final boolean inverse;
+
+    @JsonCreator
+    public KilledByPlayerPredicate(
+        @JsonProperty("inverse") boolean inverse) {
+        this.inverse = inverse;
+    }
+
+    public boolean getInverse() {
+        return inverse;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/LocationCheckPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/LocationCheckPredicate.java
@@ -1,0 +1,44 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Location;
+
+import java.util.OptionalInt;
+
+public class LocationCheckPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:location_check";
+
+    private final OptionalInt offsetX;
+    private final OptionalInt offsetY;
+    private final OptionalInt offsetZ;
+    private final Location predicate;
+
+    @JsonCreator
+    public LocationCheckPredicate(
+        @JsonProperty("offsetX") OptionalInt offsetX,
+        @JsonProperty("offsetY") OptionalInt offsetY,
+        @JsonProperty("offsetZ") OptionalInt offsetZ,
+        @JsonProperty("predicate") Location predicate) {
+        this.offsetX = offsetX;
+        this.offsetY = offsetY;
+        this.offsetZ = offsetZ;
+        this.predicate = predicate;
+    }
+
+    public OptionalInt getOffsetX() {
+        return offsetX;
+    }
+
+    public OptionalInt getOffsetY() {
+        return offsetY;
+    }
+
+    public OptionalInt getOffsetZ() {
+        return offsetZ;
+    }
+
+    public Location getPredicate() {
+        return predicate;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/MatchToolPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/MatchToolPredicate.java
@@ -1,0 +1,21 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Item;
+
+public class MatchToolPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:match_tool";
+
+    private final Item predicate;
+
+    @JsonCreator
+    public MatchToolPredicate(
+        @JsonProperty("predicate") Item predicate) {
+        this.predicate = predicate;
+    }
+
+    public Item getPredicate() {
+        return predicate;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/Predicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/Predicate.java
@@ -1,0 +1,31 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "condition"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = AlternativePredicate.class, name = AlternativePredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = BlockStatePropertyPredicate.class, name = BlockStatePropertyPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = DamageSourcePropertiesPredicate.class, name = DamageSourcePropertiesPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = EntityPropertiesPredicate.class, name = EntityPropertiesPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = EntityScoresPredicate.class, name = EntityScoresPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = InvertedPredicate.class, name = InvertedPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = KilledByPlayerPredicate.class, name = KilledByPlayerPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = LocationCheckPredicate.class, name = LocationCheckPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = MatchToolPredicate.class, name = MatchToolPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = RandomChancePredicate.class, name = RandomChancePredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = RandomChanceWhileLootingPredicate.class, name = RandomChanceWhileLootingPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = ReferencePredicate.class, name = ReferencePredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = SurvivesExplosionPredicate.class, name = SurvivesExplosionPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = TableBonusPredicate.class, name = TableBonusPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = TimeCheckPredicate.class, name = TimeCheckPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = ToolEnchantmentPredicate.class, name = ToolEnchantmentPredicate.TYPE_ID),
+    @JsonSubTypes.Type(value = WeatherCheckPredicate.class, name = WeatherCheckPredicate.TYPE_ID),
+})
+public interface Predicate {
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/RandomChancePredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/RandomChancePredicate.java
@@ -1,0 +1,20 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RandomChancePredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:random_chance";
+
+    private final float chance;
+
+    @JsonCreator
+    public RandomChancePredicate(
+        @JsonProperty("chance") float chance) {
+        this.chance = chance;
+    }
+
+    public float getChance() {
+        return chance;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/RandomChanceWhileLootingPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/RandomChanceWhileLootingPredicate.java
@@ -1,0 +1,27 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RandomChanceWhileLootingPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:random_chance_with_looting";
+
+    private final float chance;
+    private final float lootingMultiplier;
+
+    @JsonCreator
+    public RandomChanceWhileLootingPredicate(
+        @JsonProperty("chance") float chance,
+        @JsonProperty("looting_multiplier") float lootingMultiplier) {
+        this.chance = chance;
+        this.lootingMultiplier = lootingMultiplier;
+    }
+
+    public float getChance() {
+        return chance;
+    }
+
+    public float getLootingMultiplier() {
+        return lootingMultiplier;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/ReferencePredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/ReferencePredicate.java
@@ -1,0 +1,20 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ReferencePredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:reference";
+
+    private final String name;
+
+    @JsonCreator
+    public ReferencePredicate(
+        @JsonProperty("name") String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/SurvivesExplosionPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/SurvivesExplosionPredicate.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+public class SurvivesExplosionPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:survives_explosion";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/TableBonusPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/TableBonusPredicate.java
@@ -1,0 +1,29 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class TableBonusPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:table_bonus";
+
+    private final int enchantment;
+    private final List<Float> chances;
+
+    @JsonCreator
+    public TableBonusPredicate(
+        @JsonProperty("enchantment") int enchantment,
+        @JsonProperty("chances") List<Float> chances) {
+        this.enchantment = enchantment;
+        this.chances = chances;
+    }
+
+    public int getEnchantment() {
+        return enchantment;
+    }
+
+    public List<Float> getChances() {
+        return chances;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/TimeCheckPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/TimeCheckPredicate.java
@@ -1,0 +1,30 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.RangedInt;
+
+import java.util.OptionalInt;
+
+public class TimeCheckPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:time_check";
+
+    private final RangedInt value;
+    private final OptionalInt period;
+
+    @JsonCreator
+    public TimeCheckPredicate(
+        @JsonProperty("value") RangedInt value,
+        @JsonProperty("period") OptionalInt period) {
+        this.value = value;
+        this.period = period;
+    }
+
+    public RangedInt getValue() {
+        return value;
+    }
+
+    public OptionalInt getPeriod() {
+        return period;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/ToolEnchantmentPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/ToolEnchantmentPredicate.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.glowstone.datapack.loader.model.external.advancement.condition.prop.Enchantment;
+
+import java.util.List;
+
+public class ToolEnchantmentPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:tool_enchantment";
+
+    private final List<Enchantment> enchantments;
+
+    @JsonCreator
+    public ToolEnchantmentPredicate(
+        @JsonProperty("enchantments") List<Enchantment> enchantments) {
+        this.enchantments = enchantments;
+    }
+
+    public List<Enchantment> getEnchantments() {
+        return enchantments;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/WeatherCheckPredicate.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/predicate/WeatherCheckPredicate.java
@@ -1,0 +1,27 @@
+package net.glowstone.datapack.loader.model.external.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class WeatherCheckPredicate implements Predicate {
+    public static final String TYPE_ID = "minecraft:weather_check";
+
+    private final boolean raining;
+    private final boolean thundering;
+
+    @JsonCreator
+    public WeatherCheckPredicate(
+        @JsonProperty("raining") boolean raining,
+        @JsonProperty("thundering") boolean thundering) {
+        this.raining = raining;
+        this.thundering = thundering;
+    }
+
+    public boolean isRaining() {
+        return raining;
+    }
+
+    public boolean isThundering() {
+        return thundering;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/BlastingRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/BlastingRecipe.java
@@ -1,0 +1,51 @@
+package net.glowstone.datapack.loader.model.external.recipe;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Feature;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class BlastingRecipe implements GroupableRecipe {
+    public static final String TYPE_ID = "minecraft:blasting";
+
+    private final String group;
+    private final List<Item> ingredient;
+    private final String result;
+    private final double experience;
+    private final int cookingTime;
+
+    public BlastingRecipe(
+        @JsonProperty("group") String group,
+        @JsonProperty("ingredient") @JsonFormat(with = Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) List<Item> ingredient,
+        @JsonProperty("result") String result,
+        @JsonProperty("experience") double experience,
+        @JsonProperty("cookingtime") int cookingTime) {
+        this.group = group;
+        this.ingredient = ingredient;
+        this.result = result;
+        this.experience = experience;
+        this.cookingTime = cookingTime;
+    }
+
+    @Override
+    public String getGroup() {
+        return group;
+    }
+
+    public List<Item> getIngredient() {
+        return ingredient;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public double getExperience() {
+        return experience;
+    }
+
+    public int getCookingTime() {
+        return cookingTime;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/CampfireCookingRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/CampfireCookingRecipe.java
@@ -1,0 +1,51 @@
+package net.glowstone.datapack.loader.model.external.recipe;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Feature;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class CampfireCookingRecipe implements GroupableRecipe {
+    public static final String TYPE_ID = "minecraft:campfire_cooking";
+
+    private final String group;
+    private final List<Item> ingredient;
+    private final String result;
+    private final double experience;
+    private final int cookingTime;
+
+    public CampfireCookingRecipe(
+        @JsonProperty("group") String group,
+        @JsonProperty("ingredient") @JsonFormat(with = Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) List<Item> ingredient,
+        @JsonProperty("result") String result,
+        @JsonProperty("experience") double experience,
+        @JsonProperty("cookingtime") int cookingTime) {
+        this.group = group;
+        this.ingredient = ingredient;
+        this.result = result;
+        this.experience = experience;
+        this.cookingTime = cookingTime;
+    }
+
+    @Override
+    public String getGroup() {
+        return group;
+    }
+
+    public List<Item> getIngredient() {
+        return ingredient;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public double getExperience() {
+        return experience;
+    }
+
+    public int getCookingTime() {
+        return cookingTime;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/CraftingResult.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/CraftingResult.java
@@ -1,0 +1,23 @@
+package net.glowstone.datapack.loader.model.external.recipe;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CraftingResult {
+    private final int count;
+    private final String item;
+
+    public CraftingResult(
+        @JsonProperty(value = "count", defaultValue = "1") int count,
+        @JsonProperty("item") String item) {
+        this.count = count;
+        this.item = item;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public String getItem() {
+        return item;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/GroupableRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/GroupableRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe;
+
+public interface GroupableRecipe extends Recipe {
+    String getGroup();
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/Item.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/Item.java
@@ -1,0 +1,25 @@
+package net.glowstone.datapack.loader.model.external.recipe;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Item {
+    private final String item;
+    private final String tag;
+
+    @JsonCreator
+    public Item(
+        @JsonProperty("item") String item,
+        @JsonProperty("tag") String tag) {
+        this.item = item;
+        this.tag = tag;
+    }
+
+    public String getItem() {
+        return item;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/Recipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/Recipe.java
@@ -1,0 +1,49 @@
+package net.glowstone.datapack.loader.model.external.recipe;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import net.glowstone.datapack.loader.model.external.recipe.special.ArmorDyeRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.BannerAddPatternRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.BannerDuplicateRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.BookCloningRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.FireworkRocketRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.FireworkStarFadeRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.FireworkStarRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.MapCloningRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.MapExtendingRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.RepairItemRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.ShieldDecorationRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.ShulkerBoxColoringRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.SuspiciousStewRecipe;
+import net.glowstone.datapack.loader.model.external.recipe.special.TippedArrowRecipe;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ArmorDyeRecipe.class, name = ArmorDyeRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = BannerAddPatternRecipe.class, name = BannerAddPatternRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = BannerDuplicateRecipe.class, name = BannerDuplicateRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = BookCloningRecipe.class, name = BookCloningRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = FireworkRocketRecipe.class, name = FireworkRocketRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = FireworkStarRecipe.class, name = FireworkStarRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = FireworkStarFadeRecipe.class, name = FireworkStarFadeRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = MapCloningRecipe.class, name = MapCloningRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = MapExtendingRecipe.class, name = MapExtendingRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = RepairItemRecipe.class, name = RepairItemRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = ShieldDecorationRecipe.class, name = ShieldDecorationRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = ShulkerBoxColoringRecipe.class, name = ShulkerBoxColoringRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = TippedArrowRecipe.class, name = TippedArrowRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = SuspiciousStewRecipe.class, name = SuspiciousStewRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = ShapedRecipe.class, name = ShapedRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = ShapelessRecipe.class, name = ShapelessRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = SmeltingRecipe.class, name = SmeltingRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = SmokingRecipe.class, name = SmokingRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = StonecuttingRecipe.class, name = StonecuttingRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = BlastingRecipe.class, name = BlastingRecipe.TYPE_ID),
+    @JsonSubTypes.Type(value = CampfireCookingRecipe.class, name = CampfireCookingRecipe.TYPE_ID),
+})
+public interface Recipe {
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/ShapedRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/ShapedRecipe.java
@@ -1,0 +1,46 @@
+package net.glowstone.datapack.loader.model.external.recipe;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Feature;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+public class ShapedRecipe implements GroupableRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_shaped";
+
+    private final String group;
+    private final List<String> pattern;
+    private final Map<Character, List<Item>> key;
+    private final CraftingResult result;
+
+    public ShapedRecipe(
+        @JsonProperty("group") String group,
+        @JsonProperty("pattern") @JsonFormat(with = Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) List<String> pattern,
+        @JsonProperty("key") Map<Character, List<Item>> key,
+        @JsonProperty("result") CraftingResult result) {
+        this.group = group;
+        this.pattern = pattern;
+        this.key = key;
+        this.result = result;
+    }
+
+    @Override
+    public String getGroup() {
+        return group;
+    }
+
+    public List<String> getPattern() {
+        return pattern;
+    }
+
+    public Map<Character, List<Item>> getKey() {
+        return key;
+    }
+
+    public CraftingResult getResult() {
+        return result;
+    }
+
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/ShapelessRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/ShapelessRecipe.java
@@ -1,0 +1,36 @@
+package net.glowstone.datapack.loader.model.external.recipe;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Feature;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class ShapelessRecipe implements GroupableRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_shapeless";
+
+    private final String group;
+    private final List<List<Item>> ingredients;
+    private final CraftingResult result;
+
+    public ShapelessRecipe(
+        @JsonProperty("group") String group,
+        @JsonProperty("ingredients") @JsonFormat(with = Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) List<List<Item>> ingredients,
+        @JsonProperty("result") CraftingResult result) {
+        this.group = group;
+        this.ingredients = ingredients;
+        this.result = result;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public List<List<Item>> getIngredients() {
+        return ingredients;
+    }
+
+    public CraftingResult getResult() {
+        return result;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/SmeltingRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/SmeltingRecipe.java
@@ -1,0 +1,51 @@
+package net.glowstone.datapack.loader.model.external.recipe;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Feature;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class SmeltingRecipe implements GroupableRecipe {
+    public static final String TYPE_ID = "minecraft:smelting";
+
+    private final String group;
+    private final List<Item> ingredient;
+    private final String result;
+    private final double experience;
+    private final int cookingTime;
+
+    public SmeltingRecipe(
+        @JsonProperty("group") String group,
+        @JsonProperty("ingredient") @JsonFormat(with = Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) List<Item> ingredient,
+        @JsonProperty("result") String result,
+        @JsonProperty("experience") double experience,
+        @JsonProperty("cookingtime") int cookingTime) {
+        this.group = group;
+        this.ingredient = ingredient;
+        this.result = result;
+        this.experience = experience;
+        this.cookingTime = cookingTime;
+    }
+
+    @Override
+    public String getGroup() {
+        return group;
+    }
+
+    public List<Item> getIngredient() {
+        return ingredient;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public double getExperience() {
+        return experience;
+    }
+
+    public int getCookingTime() {
+        return cookingTime;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/SmokingRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/SmokingRecipe.java
@@ -1,0 +1,51 @@
+package net.glowstone.datapack.loader.model.external.recipe;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Feature;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class SmokingRecipe implements GroupableRecipe {
+    public static final String TYPE_ID = "minecraft:smoking";
+
+    private final String group;
+    private final List<Item> ingredient;
+    private final String result;
+    private final double experience;
+    private final int cookingTime;
+
+    public SmokingRecipe(
+        @JsonProperty("group") String group,
+        @JsonProperty("ingredient") @JsonFormat(with = Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) List<Item> ingredient,
+        @JsonProperty("result") String result,
+        @JsonProperty("experience") double experience,
+        @JsonProperty("cookingtime") int cookingTime) {
+        this.group = group;
+        this.ingredient = ingredient;
+        this.result = result;
+        this.experience = experience;
+        this.cookingTime = cookingTime;
+    }
+
+    @Override
+    public String getGroup() {
+        return group;
+    }
+
+    public List<Item> getIngredient() {
+        return ingredient;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public double getExperience() {
+        return experience;
+    }
+
+    public int getCookingTime() {
+        return cookingTime;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/StonecuttingRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/StonecuttingRecipe.java
@@ -1,0 +1,40 @@
+package net.glowstone.datapack.loader.model.external.recipe;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Feature;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class StonecuttingRecipe implements GroupableRecipe {
+    public static final String TYPE_ID = "minecraft:stonecutting";
+
+    private final String group;
+    private final List<Item> ingredient;
+    private final String result;
+    private final int count;
+
+    public StonecuttingRecipe(
+        @JsonProperty("group") String group,
+        @JsonProperty("ingredient") @JsonFormat(with = Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) List<Item> ingredient,
+        @JsonProperty("result") String result,
+        @JsonProperty("count") int count) {
+        this.group = group;
+        this.ingredient = ingredient;
+        this.result = result;
+        this.count = count;
+    }
+
+    @Override
+    public String getGroup() {
+        return group;
+    }
+
+    public List<Item> getIngredient() {
+        return ingredient;
+    }
+
+    public String getResult() {
+        return result;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/ArmorDyeRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/ArmorDyeRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class ArmorDyeRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_armordye";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/BannerAddPatternRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/BannerAddPatternRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class BannerAddPatternRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_banneraddpattern";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/BannerDuplicateRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/BannerDuplicateRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class BannerDuplicateRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_bannerduplicate";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/BookCloningRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/BookCloningRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class BookCloningRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_bookcloning";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/FireworkRocketRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/FireworkRocketRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class FireworkRocketRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_firework_rocket";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/FireworkStarFadeRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/FireworkStarFadeRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class FireworkStarFadeRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_firework_star_fade";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/FireworkStarRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/FireworkStarRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class FireworkStarRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_firework_star";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/MapCloningRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/MapCloningRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class MapCloningRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_mapcloning";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/MapExtendingRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/MapExtendingRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class MapExtendingRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_mapextending";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/RepairItemRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/RepairItemRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class RepairItemRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_repairitem";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/ShieldDecorationRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/ShieldDecorationRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class ShieldDecorationRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_shielddecoration";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/ShulkerBoxColoringRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/ShulkerBoxColoringRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class ShulkerBoxColoringRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_shulkerboxcoloring";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/SpecialRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/SpecialRecipe.java
@@ -1,0 +1,6 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+import net.glowstone.datapack.loader.model.external.recipe.Recipe;
+
+public interface SpecialRecipe extends Recipe {
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/SuspiciousStewRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/SuspiciousStewRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class SuspiciousStewRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_suspiciousstew";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/TippedArrowRecipe.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/recipe/special/TippedArrowRecipe.java
@@ -1,0 +1,5 @@
+package net.glowstone.datapack.loader.model.external.recipe.special;
+
+public class TippedArrowRecipe implements SpecialRecipe {
+    public static final String TYPE_ID = "minecraft:crafting_special_tippedarrow";
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/structures/Structure.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/structures/Structure.java
@@ -1,0 +1,14 @@
+package net.glowstone.datapack.loader.model.external.structures;
+
+// TODO: Actually parse the NBT.
+public class Structure {
+    private final String nbt;
+
+    public Structure(String nbt) {
+        this.nbt = nbt;
+    }
+
+    public String getNbt() {
+        return nbt;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/tag/Tag.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/tag/Tag.java
@@ -1,0 +1,16 @@
+package net.glowstone.datapack.loader.model.external.tag;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class Tag {
+    private final boolean replace;
+    private final List<String> values;
+
+    public Tag(
+        @JsonProperty("replace") boolean replace,
+        @JsonProperty("values") List<String> values) {
+        this.replace = replace;
+        this.values = values;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/text/ClickEvent.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/text/ClickEvent.java
@@ -1,0 +1,33 @@
+package net.glowstone.datapack.loader.model.external.text;
+
+import static net.glowstone.datapack.loader.jackson.JsonNodeHandling.valueAsString;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class ClickEvent {
+    @JsonCreator
+    public static ClickEvent fromJson(JsonNode rootNode) throws JsonMappingException {
+        return new ClickEvent(
+            valueAsString(rootNode, "action").orElse(null),
+            valueAsString(rootNode, "value").orElse(null)
+        );
+    }
+
+    private final String action;
+    private final String value;
+
+    public ClickEvent(String action, String value) {
+        this.action = action;
+        this.value = value;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/text/HoverEvent.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/text/HoverEvent.java
@@ -1,0 +1,26 @@
+package net.glowstone.datapack.loader.model.external.text;
+
+import static net.glowstone.datapack.loader.jackson.JsonNodeHandling.valueAsObject;
+import static net.glowstone.datapack.loader.jackson.JsonNodeHandling.valueAsString;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class HoverEvent {
+    @JsonCreator
+    public static HoverEvent fromJson(JsonNode rootNode) throws JsonMappingException {
+        return new HoverEvent(
+            valueAsString(rootNode, "action").orElse(null),
+            valueAsObject(rootNode, "value", RawJsonText::fromJson).orElse(null)
+        );
+    }
+
+    private final String action;
+    private final RawJsonText value;
+
+    public HoverEvent(String action, RawJsonText value) {
+        this.action = action;
+        this.value = value;
+    }
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/text/RawJsonText.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/text/RawJsonText.java
@@ -1,0 +1,205 @@
+package net.glowstone.datapack.loader.model.external.text;
+
+import static net.glowstone.datapack.loader.jackson.JsonNodeHandling.valueAsBoolean;
+import static net.glowstone.datapack.loader.jackson.JsonNodeHandling.valueAsList;
+import static net.glowstone.datapack.loader.jackson.JsonNodeHandling.valueAsObject;
+import static net.glowstone.datapack.loader.jackson.JsonNodeHandling.valueAsString;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.util.List;
+import java.util.Optional;
+
+public class RawJsonText {
+    @JsonCreator
+    public static RawJsonText fromJson(JsonNode rootNode) throws JsonMappingException {
+        if (rootNode.isTextual()) {
+            return fromJsonObject(JsonNodeFactory.instance.objectNode().set("text", rootNode));
+        } else if (rootNode.isArray()) {
+            return fromJsonObject(JsonNodeFactory.instance.objectNode().set("extra", rootNode));
+        } else if (rootNode.isObject()) {
+            return fromJsonObject(rootNode);
+        }
+        throw new JsonMappingException(null, "Cannot create RawJsonText");
+    }
+
+    private static RawJsonText fromJsonObject(JsonNode rootNode) throws JsonMappingException {
+        return new RawJsonText(
+            valueAsString(rootNode, "text"),
+            valueAsString(rootNode, "translate"),
+            valueAsList(rootNode, "with", RawJsonText::fromJson),
+            valueAsObject(rootNode, "score", Score::fromJson),
+            valueAsString(rootNode, "selector"),
+            valueAsString(rootNode, "keybind"),
+            valueAsString(rootNode, "nbt"),
+            valueAsBoolean(rootNode, "interpret"),
+            valueAsString(rootNode, "block"),
+            valueAsString(rootNode, "entity"),
+            valueAsString(rootNode, "storage"),
+            valueAsString(rootNode, "color"),
+            valueAsBoolean(rootNode, "bold"),
+            valueAsBoolean(rootNode, "italic"),
+            valueAsBoolean(rootNode, "underlined"),
+            valueAsBoolean(rootNode, "strikethrough"),
+            valueAsBoolean(rootNode, "obfuscated"),
+            valueAsString(rootNode, "insertion"),
+            valueAsObject(rootNode, "clickEvent", ClickEvent::fromJson),
+            valueAsObject(rootNode, "hoverEvent", HoverEvent::fromJson),
+            valueAsList(rootNode, "extra", RawJsonText::fromJson)
+        );
+    }
+
+    private final String text;
+    private final String translate;
+    private final List<RawJsonText> with;
+    private final Score score;
+    private final String selector;
+    private final String keybind;
+    private final String nbt;
+    private final Boolean interpret;
+    private final String block;
+    private final String entity;
+    private final String storage;
+    private final String color;
+    private final boolean bold;
+    private final boolean italic;
+    private final boolean underlined;
+    private final boolean strikethrough;
+    private final boolean obfuscated;
+    private final String insertion;
+    private final ClickEvent clickEvent;
+    private final HoverEvent hoverEvent;
+    private final List<RawJsonText> extra;
+
+    private RawJsonText(
+        Optional<String> text,
+        Optional<String> translate,
+        Optional<List<RawJsonText>> with,
+        Optional<Score> score,
+        Optional<String> selector,
+        Optional<String> keybind,
+        Optional<String> nbt,
+        Optional<Boolean> interpret,
+        Optional<String> block,
+        Optional<String> entity,
+        Optional<String> storage,
+        Optional<String> color,
+        Optional<Boolean> bold,
+        Optional<Boolean> italic,
+        Optional<Boolean> underlined,
+        Optional<Boolean> strikethrough,
+        Optional<Boolean> obfuscated,
+        Optional<String> insertion,
+        Optional<ClickEvent> clickEvent,
+        Optional<HoverEvent> hoverEvent,
+        Optional<List<RawJsonText>> extra) {
+        this.text = text.orElse(null);
+        this.translate = translate.orElse(null);
+        this.with = with.orElse(null);
+        this.score = score.orElse(null);
+        this.selector = selector.orElse(null);
+        this.keybind = keybind.orElse(null);
+        this.nbt = nbt.orElse(null);
+        this.interpret = interpret.orElse(null);
+        this.block = block.orElse(null);
+        this.entity = entity.orElse(null);
+        this.storage = storage.orElse(null);
+        this.color = color.orElse(null);
+        this.bold = bold.orElse(false);
+        this.italic = italic.orElse(false);
+        this.underlined = underlined.orElse(false);
+        this.strikethrough = strikethrough.orElse(false);
+        this.obfuscated = obfuscated.orElse(false);
+        this.insertion = insertion.orElse(null);
+        this.clickEvent = clickEvent.orElse(null);
+        this.hoverEvent = hoverEvent.orElse(null);
+        this.extra = extra.orElse(null);
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public String getTranslate() {
+        return translate;
+    }
+
+    public List<RawJsonText> getWith() {
+        return with;
+    }
+
+    public Score getScore() {
+        return score;
+    }
+
+    public String getSelector() {
+        return selector;
+    }
+
+    public String getKeybind() {
+        return keybind;
+    }
+
+    public String getNbt() {
+        return nbt;
+    }
+
+    public Boolean getInterpret() {
+        return interpret;
+    }
+
+    public String getBlock() {
+        return block;
+    }
+
+    public String getEntity() {
+        return entity;
+    }
+
+    public String getStorage() {
+        return storage;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public boolean isBold() {
+        return bold;
+    }
+
+    public boolean isItalic() {
+        return italic;
+    }
+
+    public boolean isUnderlined() {
+        return underlined;
+    }
+
+    public boolean isStrikethrough() {
+        return strikethrough;
+    }
+
+    public boolean isObfuscated() {
+        return obfuscated;
+    }
+
+    public String getInsertion() {
+        return insertion;
+    }
+
+    public ClickEvent getClickEvent() {
+        return clickEvent;
+    }
+
+    public HoverEvent getHoverEvent() {
+        return hoverEvent;
+    }
+
+    public List<RawJsonText> getExtra() {
+        return extra;
+    }
+
+}

--- a/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/text/Score.java
+++ b/data-pack-loader/src/main/java/net/glowstone/datapack/loader/model/external/text/Score.java
@@ -1,0 +1,40 @@
+package net.glowstone.datapack.loader.model.external.text;
+
+import static net.glowstone.datapack.loader.jackson.JsonNodeHandling.valueAsString;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class Score {
+    @JsonCreator
+    public static Score fromJson(JsonNode rootNode) throws JsonMappingException {
+        return new Score(
+            valueAsString(rootNode, "name").orElse(null),
+            valueAsString(rootNode, "objective").orElse(null),
+            valueAsString(rootNode, "value").orElse(null)
+        );
+    }
+
+    private final String name;
+    private final String objective;
+    private final String value;
+
+    public Score(String name, String objective, String value) {
+        this.name = name;
+        this.objective = objective;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getObjective() {
+        return objective;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/data-pack-loader/src/test/java/net/glowstone/datapack/loader/DataPackLoaderTest.java
+++ b/data-pack-loader/src/test/java/net/glowstone/datapack/loader/DataPackLoaderTest.java
@@ -1,0 +1,27 @@
+package net.glowstone.datapack.loader;
+
+import net.glowstone.datapack.loader.model.external.DataPack;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DataPackLoaderTest {
+    @Test
+    @Disabled
+    void loadPacks() throws Exception {
+        // TODO; Must copy vanilla minecraft datapack before running this test.
+
+        URL vanillaResource = DataPackLoaderTest.class.getResource("/data-packs/vanilla/pack.mcmeta");
+        Path vanillaPath = Paths.get(vanillaResource.toURI()).getParent().getParent();
+
+        Map<String, DataPack> dataPacks = new DataPackLoader().loadPacks(vanillaPath);
+
+        assertEquals(1, dataPacks.size());
+    }
+}

--- a/data-pack-loader/src/test/resources/data-packs/vanilla/pack.mcmeta
+++ b/data-pack-loader/src/test/resources/data-packs/vanilla/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "description": "The vanilla data pack",
+    "pack_format": 5
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
     <properties>
         <minecraft.version>1.15.2</minecraft.version>
         <glowkit.version>-R0.1-SNAPSHOT</glowkit.version>
+        <jackson.version>2.10.1</jackson.version>
+        <java.version>1.8</java.version>
     </properties>
 
     <repositories>
@@ -36,6 +38,35 @@
                 <artifactId>glowkit</artifactId>
                 <version>${minecraft.version}${glowkit.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>28.2-jre</version>
+            </dependency>
+
+            <!-- Test dependencies -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.5.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-runner</artifactId>
+                <version>1.5.2</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -47,8 +78,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.0</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -80,6 +111,23 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.platform</groupId>
+                            <artifactId>junit-platform-surefire-provider</artifactId>
+                            <version>1.2.0</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <additionalClasspathElements>
+                            <additionalClasspathElement>src/test/java/</additionalClasspathElement>
+                        </additionalClasspathElements>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -89,5 +137,6 @@
         <module>block-data-base</module>
         <module>block-data-generated</module>
         <module>block-data-annotations</module>
+        <module>data-pack-loader</module>
     </modules>
 </project>


### PR DESCRIPTION
This change adds the data-pack-loader module, which models data packs and loads them up (minus functions and structures). It was tested against vanilla's data pack using the provided unit test, although its not included in this PR. This could use some cleanup, but it works.