### PR TITLE
Remove BlockDataConstructor map and replace with props map.

### DIFF
--- a/block-data-base/src/main/java/net/glowstone/block/data/states/AbstractStatefulBlockData.java
+++ b/block-data-base/src/main/java/net/glowstone/block/data/states/AbstractStatefulBlockData.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableMap;
 import net.glowstone.block.data.states.reports.ComparableStateReport;
 import net.glowstone.block.data.states.reports.StateReport;
 import net.glowstone.block.data.states.values.StateValue;
@@ -18,7 +20,7 @@ public abstract class AbstractStatefulBlockData implements StatefulBlockData {
 
     protected AbstractStatefulBlockData(Material material, Map<String, StateValue<?>> stateValues, boolean explicit) {
         this.material = material;
-        this.stateValues = stateValues;
+        this.stateValues = ImmutableMap.copyOf(stateValues);
         this.explicit = explicit;
     }
 
@@ -90,7 +92,7 @@ public abstract class AbstractStatefulBlockData implements StatefulBlockData {
         if (statefulData.explicit) {
             statefulData.stateValues.forEach((propName, propValue) -> {
                 if (propValue.hasValue() && !propValue.hasBeenModified()) {
-                    newData.stateValues.put(propName, propValue);
+                    newData.stateValues.get(propName).setRawValue(propValue.getValue());
                 }
             });
         }

--- a/block-data-base/src/main/java/net/glowstone/block/data/states/StatefulBlockData.java
+++ b/block-data-base/src/main/java/net/glowstone/block/data/states/StatefulBlockData.java
@@ -13,4 +13,5 @@ public interface StatefulBlockData extends BlockData {
     <T extends Comparable<T>> T getMaxValue(String propName, Class<T> propType);
     boolean hasValue(String propName);
     Map<String, String> getSerializedStateProps();
+    @Override StatefulBlockData clone();
 }

--- a/block-data-base/src/main/java/net/glowstone/block/data/states/reports/StateReport.java
+++ b/block-data-base/src/main/java/net/glowstone/block/data/states/reports/StateReport.java
@@ -2,9 +2,11 @@ package net.glowstone.block.data.states.reports;
 
 import java.util.Optional;
 import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
 import net.glowstone.block.data.states.values.StateValue;
 
-public abstract class StateReport<T> implements Cloneable {
+public abstract class StateReport<T> {
     private final Class<T> valueType;
     private final T defaultValue;
     private final Set<T> validValues;
@@ -12,7 +14,7 @@ public abstract class StateReport<T> implements Cloneable {
     protected StateReport(Class<T> valueType, T defaultValue, Set<T> validValues) {
         this.valueType = valueType;
         this.defaultValue = defaultValue;
-        this.validValues = validValues;
+        this.validValues = ImmutableSet.copyOf(validValues);
     }
 
     public abstract String stringifyValue(T value);


### PR DESCRIPTION
@mastercoms Found the implementation of convertIdToBlockData() vs createBlockData() within AbstractBlockDataManager confusing. This PR changes the implementation of createBlockData() to be similar to convertIdToBlockData() by keeping a mapping of material+props -> BlockData instance.